### PR TITLE
feat: Add server warmup indicator and deployment design

### DIFF
--- a/.design/deployment.md
+++ b/.design/deployment.md
@@ -1,0 +1,416 @@
+# Deployment Strategy Design
+
+**Status:** Draft
+**Last Updated:** 2026-01-20
+
+## Executive Summary
+
+This document defines the CI/CD deployment strategy for CatanWeb using Azure App Service
+deployment slots with branch-based triggers:
+
+- **`main` branch** → Production (catan.azurewebsites.net)
+- **`staging` branch** → Staging slot (catan-staging.azurewebsites.net)
+
+## Current State
+
+### CatanWeb Repository
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| CI | push to main, PRs to main | Build & test |
+| Deploy to Azure | push to main | Deploy to production |
+| CodeQL | various | Security scanning |
+| Claude/Copilot | PRs | Code review |
+
+### Catan3 Repository
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| Claude Code Review | PRs | Code review |
+| Claude Code | PRs | Code review |
+
+**Note:** Catan3 is the WinUI3 desktop app. It has no deployment workflows - any previous Azure
+deployment workflow has been removed. The desktop app is distributed as an MSIX package.
+**No changes needed there.**
+
+### Current Azure Resources
+
+```text
+Resource Group: rg-catan
+├── App Service Plan: asp-catan
+├── App Service (UI): catan → https://catan.azurewebsites.net
+├── App Service (API): catan-api → https://catan-api.azurewebsites.net
+├── SQL Server: sql-catan.database.windows.net
+│   └── Database: catan
+├── Storage Account: stcatan
+└── Application Insights: ai-catan
+```
+
+## Proposed Architecture
+
+### Azure Deployment Slots
+
+Azure App Service deployment slots are the recommended approach for staging environments:
+
+**Advantages:**
+
+- Same infrastructure, different URL
+- Instant swap between staging and production
+- Easy rollback by swapping back
+- Staging slot warms up before swap
+- Shared App Service Plan (no extra compute cost for Basic+ tiers)
+
+**URL Pattern:**
+
+| Environment | UI URL | API URL |
+|-------------|--------|---------|
+| Production | catan.azurewebsites.net | catan-api.azurewebsites.net |
+| Staging | catan-staging.azurewebsites.net | catan-api-staging.azurewebsites.net |
+
+### Branch Strategy
+
+```text
+                    ┌─────────────────────────────────────┐
+                    │         Feature Branches            │
+                    │   (feat/*, fix/*, refactor/*, etc) │
+                    └─────────────┬───────────────────────┘
+                                  │ PR
+                                  ▼
+                    ┌─────────────────────────────────────┐
+                    │           staging branch            │
+                    │  Auto-deploy to staging slot        │
+                    │  Integration testing environment    │
+                    └─────────────┬───────────────────────┘
+                                  │ PR (after validation)
+                                  ▼
+                    ┌─────────────────────────────────────┐
+                    │            main branch              │
+                    │  Auto-deploy to production          │
+                    │  Stable, production-ready code      │
+                    └─────────────────────────────────────┘
+```
+
+### Workflow Triggers
+
+| Branch | CI (Build/Test) | Deploy |
+|--------|-----------------|--------|
+| Feature branches | On PR to staging or main | None |
+| staging | On push | Deploy to staging slot |
+| main | On push | Deploy to production |
+
+## Implementation Plan
+
+### Phase 1: Create Azure Deployment Slots
+
+Create staging slots for both App Services:
+
+```bash
+# Create staging slot for UI
+az webapp deployment slot create \
+  --name catan \
+  --resource-group rg-catan \
+  --slot staging
+
+# Create staging slot for API
+az webapp deployment slot create \
+  --name catan-api \
+  --resource-group rg-catan \
+  --slot staging
+```
+
+**Configuration for staging slots:**
+
+- Copy production app settings to staging slot
+- Update any environment-specific settings (e.g., `ASPNETCORE_ENVIRONMENT=Staging`)
+- Configure staging slot to use the same database (or a staging database if desired)
+
+### Phase 2: Update GitHub Actions Workflows
+
+#### 2.1 Modify CI Workflow
+
+Update `.github/workflows/ci.yml` to trigger on PRs to both main and staging:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+```
+
+#### 2.2 Split Deploy Workflow
+
+Create two deployment workflows or parameterize the existing one:
+
+##### Option A: Single workflow with matrix (Recommended)
+
+```yaml
+name: Deploy to Azure
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set deployment target
+        id: target
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "slot=production" >> $GITHUB_OUTPUT
+            echo "environment=production" >> $GITHUB_OUTPUT
+          else
+            echo "slot=staging" >> $GITHUB_OUTPUT
+            echo "environment=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build web projects
+        run: dotnet build CatanWeb.slnf -c Release
+
+      - name: Deploy to Azure (${{ steps.target.outputs.environment }})
+        shell: pwsh
+        run: |
+          ./catan.ps1 azure deploy -NoBuild -TraceLevel INFO -Slot ${{ steps.target.outputs.slot }}
+```
+
+##### Option B: Separate workflows
+
+- `.github/workflows/deploy-production.yml` - triggers on main
+- `.github/workflows/deploy-staging.yml` - triggers on staging
+
+### Phase 3: Update Deployment Scripts
+
+Modify `.scripts/catan-azure.ps1` to support deployment slots:
+
+1. Add `-Slot` parameter to `Deploy-GameService` and `Deploy-UI` functions
+2. Update `az webapp deploy` commands to include `--slot` when specified
+3. Update deployment tracking (DEPLOY_COMMIT setting) for slots
+
+Example changes:
+
+```powershell
+function Deploy-UI {
+    param(
+        [hashtable]$Config,
+        [switch]$Force,
+        [string]$Slot = "production"  # New parameter
+    )
+
+    $slotArg = if ($Slot -ne "production") { "--slot $Slot" } else { "" }
+
+    # Deploy command
+    Invoke-AzCommand "webapp deploy --name $appName --resource-group $rgName $slotArg ..."
+}
+```
+
+### Phase 4: Create Staging Branch
+
+```bash
+# Create staging branch from main
+git checkout main
+git checkout -b staging
+git push -u origin staging
+
+# Protect the staging branch (via GitHub UI or CLI)
+gh api repos/joelong01/CatanWeb/branches/staging/protection -X PUT -f ...
+```
+
+### Phase 5: Update Documentation
+
+1. Update CLAUDE.md with new branch strategy
+2. Update .ai/ai-rules.md with staging workflow
+3. Add deployment slot swap instructions for promoting staging to production
+
+## Deployment Slot Swap (Production Promotion)
+
+When staging is validated and ready for production, use slot swap:
+
+```bash
+# Swap staging slot to production (zero-downtime)
+az webapp deployment slot swap \
+  --name catan \
+  --resource-group rg-catan \
+  --slot staging \
+  --target-slot production
+
+az webapp deployment slot swap \
+  --name catan-api \
+  --resource-group rg-catan \
+  --slot staging \
+  --target-slot production
+```
+
+**Note:** Slot swap is instant and maintains the previous production version in the staging slot,
+enabling quick rollback if needed.
+
+## Alternative: Separate Staging Environment
+
+If deployment slots don't meet requirements (e.g., need completely isolated staging database),
+create separate Azure resources:
+
+```text
+Production:                          Staging:
+├── catan.azurewebsites.net         ├── catan-stg.azurewebsites.net
+├── catan-api.azurewebsites.net     ├── catan-api-stg.azurewebsites.net
+└── sql-catan (database: catan)     └── sql-catan (database: catan-staging)
+```
+
+This requires:
+
+- Separate App Services (additional compute cost)
+- Separate storage account or container
+- Potentially separate database
+- More complex configuration management
+
+**Recommendation:** Start with deployment slots. They're simpler, cheaper, and sufficient for most
+staging needs. Move to separate environments only if isolation requirements demand it.
+
+## Security Considerations
+
+1. **Staging slot access:** Consider adding IP restrictions or authentication to staging slot
+2. **Database access:** Staging uses same database by default; consider read-only or separate DB
+3. **Secrets:** Both slots share the same Key Vault/secrets by default
+
+## Cost Impact
+
+| Approach | Additional Cost |
+|----------|-----------------|
+| Deployment slots (Basic+ tier) | Free (included in App Service Plan) |
+| Separate App Services | ~2x App Service cost |
+
+## Rollback Procedures
+
+### From Production Issue
+
+```bash
+# Swap production back to previous version (now in staging slot)
+az webapp deployment slot swap \
+  --name catan \
+  --resource-group rg-catan \
+  --slot staging \
+  --target-slot production
+```
+
+### From Staging Issue
+
+Simply revert the staging branch or deploy a fixed version.
+
+## Current CI/CD Gap: Database Configuration
+
+**Issue:** The current `deploy-azure.yml` workflow calls `database fix` but not `database deploy`.
+
+| Command           | Configures                                           |
+|-------------------|------------------------------------------------------|
+| `database fix`    | Network access, firewall rules, schema repair        |
+| `database deploy` | All of the above PLUS connection string with pooling |
+
+The `doctor` command flags `Connection String` and `Connection Pooling` as "MISSING (run: deploy)" because
+the CI/CD doesn't configure them. The connection string was set manually during initial setup.
+
+**Fix:** Replace `database fix` with `database deploy` in `.github/workflows/deploy-azure.yml`:
+
+```yaml
+      - name: Configure database connectivity
+        shell: pwsh
+        run: |
+          ./.scripts/catan-azure.ps1 database deploy -TraceLevel INFO
+```
+
+`database deploy` is idempotent - it checks the doctor first and skips if already configured.
+
+## Implementation Checklist
+
+- [ ] **Fix database CI/CD gap** - Replace `database fix` with `database deploy` in workflow
+- [ ] Create deployment slots in Azure (UI and API)
+- [ ] Configure staging slot settings
+- [ ] Update deploy-azure.yml workflow for branch-based deployment
+- [ ] Update ci.yml to trigger on staging branch
+- [ ] Update catan-azure.ps1 to support -Slot parameter
+- [ ] Add `./catan.ps1 azure swap` command - promote staging to production (zero-downtime)
+- [ ] Add `./catan.ps1 azure rollback` command - swap back to last known good build
+- [ ] Create staging branch from main
+- [ ] Configure branch protection rules
+- [ ] Test staging deployment
+- [ ] Test production deployment from main
+- [ ] Test swap and rollback commands
+- [ ] Update project documentation
+
+## Infrastructure vs Code Deployment
+
+**Important distinction:**
+
+| Type           | What                         | How                                   | When                               |
+|----------------|------------------------------|---------------------------------------|------------------------------------|
+| Infrastructure | Resources, roles, networking | `./catan.ps1 azure install` (manual)  | One-time setup, disaster recovery  |
+| Code           | Application builds           | CI/CD (`deploy-azure.yml`)            | Every push to main/staging         |
+
+### Why Not Full CI/CD for Infrastructure?
+
+Role assignments require **Owner** or **User Access Administrator** permissions. The GitHub Actions
+service principal has **Contributor** role (cannot assign roles). This is intentional - giving CI/CD
+Owner permissions is a security risk.
+
+### Required Roles for Troubleshoot Feature
+
+The GameService managed identity needs these roles for self-healing (Troubleshoot button):
+
+| Role                        | Scope                  | Purpose                                    |
+|-----------------------------|------------------------|--------------------------------------------|
+| Reader                      | Resource Group         | Azure Resource Graph queries               |
+| SQL Server Contributor      | SQL Server             | Enable public access, manage firewall      |
+
+These are granted by `./catan.ps1 azure install` (game-service and database install commands).
+
+### Future: Infrastructure as Code (IaC)
+
+For fully automated infrastructure management, consider migrating to:
+
+- **Bicep/ARM templates** - Native Azure IaC
+- **Terraform** - Multi-cloud IaC
+- **Pulumi** - IaC with real programming languages
+
+Benefits of IaC:
+
+- Version-controlled infrastructure
+- Reproducible environments (dev/staging/prod)
+- Drift detection
+- Pull request reviews for infrastructure changes
+
+The current PowerShell scripts serve as a working reference implementation that could be translated
+to Bicep or Terraform in the future.
+
+## Questions for Review
+
+1. **Database isolation:** Should staging use the same database or a separate staging database?
+2. **Slot swap vs direct deploy:** Should main deploy directly to production, or should we always
+   go staging → swap to production?
+3. **Branch protection:** What CI checks should be required before merging to staging and main?
+4. **Access control:** Should staging slot require authentication or IP restrictions?

--- a/.design/reviews/gemini/deployment-gemini-review.md
+++ b/.design/reviews/gemini/deployment-gemini-review.md
@@ -1,0 +1,102 @@
+# Design Review: Deployment Strategy
+
+**Reviewer:** GitHub Copilot (Gemini 3 Pro Preview)
+**Date:** 2026-01-20
+**Target Document:** [.design/deployment.md](../../deployment.md)
+
+## Executive Summary
+
+The proposed deployment strategy correctly leverages Azure App Service Deployment Slots to introduce a staging environment with minimal infrastructure cost. The move to a branch-based strategy (`main` vs `staging`) provides a clear promotion path.
+
+However, the proposed workflow for the `main` branch (**Direct Deploy to Production**) underutilizes the primary benefit of deployment slots: **Safety and Zero-Downtime Swaps**.
+
+## Strengths
+
+1. **Resource Efficiency:** Using deployment slots allows for a full staging environment without incurring costs for new App Service Plans (assuming Standard tier or higher).
+2. **Clear Branching Model:** The definition of `staging` as an integration branch and `main` as production is intuitive and standard.
+3. **Infrastructure Awareness:** The document correctly identifies the limitation of CI permissions (Contributor vs Owner) and the gap in database configuration (`database fix` vs `database deploy`).
+4. **Desktop App Isolation:** Correctly identifies that the WinUI3 app is out of scope for this web-based deployment pipeline.
+
+## Critical Findings & Risks
+
+### 1. Direct Deploy vs. Swap Strategy (Major)
+
+The proposed workflow triggers a direct deployment to the production slot when code is pushed to `main`:
+
+> `main` branch -> Auto-deploy to production
+
+**Risk:** This negates the "Zero-Downtime" and "Warm-up" benefits of deployment slots. If the deployment to the production slot fails or the app fails to start, the production site goes down.
+
+**Recommendation:**
+Adopt a **"Deploy to Staging, Swap to Production"** pattern for the `main` branch as well.
+
+1. Push to `main`.
+2. CI builds and deploys to the **Staging Slot**.
+3. (Optional) Smoke tests run against Staging Slot.
+4. **Slot Swap** operation promotes Staging to Production.
+
+This ensures that the production slot is never in an invalid state during deployment.
+
+### 2. Shared Database (Critical)
+
+The document asks: *"Should staging use the same database or a separate staging database?"*
+
+**Risk:** CatanWeb uses EF Core. If a feature branch merges to `staging` and applies a migration (e.g., renaming a column), and `staging` shares the production database, **Production will break immediately** because the running code depends on the old schema.
+
+**Recommendation:**
+**Staging MUST have a separate database.**
+Given the low cost of an additional logical database in Azure SQL (or using SQLite for staging if strict parity isn't required, though SQL Server is preferred for fidelity), the risk of sharing the database is too high for a project with EF Core migrations.
+
+### 3. Build Artifact Consistency
+
+The separate workflows for `main` and `staging` imply rebuilding the application.
+
+**Observation:** Ideally, the *exact binary* tested in staging should be the one promoted to production. However, in .NET, strictly re-building for `Release` on `main` is acceptable practice if the build process is deterministic.
+
+## Detailed Recommendations
+
+### Refined Workflow Proposal
+
+Instead of Option A/B, consider this hybrid approach for `deploy-azure.yml`:
+
+```yaml
+on:
+  push:
+    branches: [ staging, main ]
+
+jobs:
+  deploy:
+    # ... setup ...
+    steps:
+      # ... build ...
+      
+      # Step 1: ALWAYS Deploy to the Staging Slot first
+      - name: Deploy to Staging Slot
+        run: ./catan.ps1 azure deploy -Slot staging ...
+
+      # Step 2: If this was 'main', Swap to Production
+      - name: Swap to Production
+        if: github.ref == 'refs/heads/main'
+        run: |
+           az webapp deployment slot swap --slot staging --target-slot production ...
+```
+
+### Database Management
+
+1. **Create `catan-staging` DB:** Provision a second database on the existing SQL Server.
+2. **App Settings:**
+    * **Production Slot:** `ConnectionStrings:DefaultConnection = ...Initial Catalog=catan...`
+    * **Staging Slot:** `ConnectionStrings:DefaultConnection = ...Initial Catalog=catan-staging...` (Use "Deployment Slot Setting" checkbox in Azure Portal to prevent this from swapping).
+
+### CI/CD Gaps
+
+* **Database Deploy:** The finding regarding `database fix` vs `database deploy` is accurate. Implementing this change is a high priority to ensure connection pooling is active.
+
+## Nitpicks
+
+* **Slot Configuration:** Ensure `ASPNETCORE_ENVIRONMENT` is marked as a "Deployment slot setting" (sticky) in Azure, so `Staging` doesn't accidentally become `Production` during a swap.
+* **Rollback:** The document mentions "From Staging Issue: Simply revert...". Just to clarify, if a bad build goes to staging, it doesn't affect prod. If a bad swap happens, you swap back.
+
+## Conclusion
+
+The design is solid but needs to strictly enforce database separation to avoid catastrophic schema conflicts. Shifting the production deployment mechanism to use "Swap" rather than "Direct Deploy" provides better resilience.

--- a/.scripts/catan-azure.ps1
+++ b/.scripts/catan-azure.ps1
@@ -626,6 +626,33 @@ function Install-Database {
     }
 
     Write-Log -Level "INFO" -Message "SQL Server ready: $($Config.sqlServer.fqdn)"
+
+    # Grant SQL Server Contributor role to GameService managed identity
+    # This allows the Troubleshoot feature to enable public network access and manage firewall rules
+    $appName = $Config.gameService.appName
+    $principalId = Invoke-AzCommand "webapp identity show --name $appName --resource-group $rgName --query principalId -o tsv" -FailOnError $false
+
+    if ($principalId) {
+        $subscriptionId = Invoke-AzCommand "account show --query id -o tsv"
+        if (-not $subscriptionId) {
+            throw "Failed to get subscription ID"
+        }
+        $sqlServerScope = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.Sql/servers/$sqlServerName"
+
+        Write-Log -Level "INFO" -Message "Granting SQL Server Contributor role to GameService managed identity..."
+        $existingRole = Invoke-AzCommand "role assignment list --assignee $principalId --role 'SQL Server Contributor' --scope $sqlServerScope --query [0].id -o tsv" -FailOnError $false
+        if (-not $existingRole) {
+            Invoke-AzCommand "role assignment create --assignee $principalId --role 'SQL Server Contributor' --scope $sqlServerScope" -SuppressOutput
+            Write-Log -Level "INFO" -Message "SQL Server Contributor role granted"
+        }
+        else {
+            Write-Log -Level "DEBUG" -Message "SQL Server Contributor role already assigned"
+        }
+    }
+    else {
+        Write-Log -Level "WARN" -Message "GameService managed identity not found - run 'game-service install' first for full Troubleshoot support"
+    }
+
     return $true
 }
 
@@ -1572,6 +1599,24 @@ function Install-GameService {
         throw "Failed to enable managed identity for $appName"
     }
     Write-Log -Level "DEBUG" -Message "Principal ID: $principalId"
+
+    # Grant Reader role on resource group for Azure Resource Graph queries
+    # This allows the Troubleshoot feature to find and inspect SQL Server resources
+    $subscriptionId = Invoke-AzCommand "account show --query id -o tsv"
+    if (-not $subscriptionId) {
+        throw "Failed to get subscription ID"
+    }
+    $rgScope = "/subscriptions/$subscriptionId/resourceGroups/$rgName"
+
+    Write-Log -Level "INFO" -Message "Granting Reader role on resource group to managed identity..."
+    $existingRole = Invoke-AzCommand "role assignment list --assignee $principalId --role Reader --scope $rgScope --query [0].id -o tsv" -FailOnError $false
+    if (-not $existingRole) {
+        Invoke-AzCommand "role assignment create --assignee $principalId --role Reader --scope $rgScope" -SuppressOutput
+        Write-Log -Level "INFO" -Message "Reader role granted on resource group"
+    }
+    else {
+        Write-Log -Level "DEBUG" -Message "Reader role already assigned on resource group"
+    }
 
     Write-Log -Level "INFO" -Message "GameService App ready: $appName"
     return $true

--- a/WebUI/Layout/MainLayout.razor.css
+++ b/WebUI/Layout/MainLayout.razor.css
@@ -1,9 +1,9 @@
 /* =============================================================================
    CSS VERSION - UPDATE THIS WHEN CSS CHANGES TO BUST BROWSER CACHE
-   Current: CSS 2026-01-15 v3
+   Current: CSS 2026-01-20 v1
 
    To update all CSS version strings at once, run from repo root:
-   sed -i '' 's/CSS 2026-01-15 v3/CSS YYYY-MM-DD vN/g' WebUI/**/*.css
+   sed -i '' 's/CSS 2026-01-20 v1/CSS YYYY-MM-DD vN/g' WebUI/**/*.css
 
    Also update query params in index.html (see that file for instructions)
    ============================================================================= */
@@ -23,7 +23,7 @@
 
 /* Global CSS version indicator - appears on all pages */
 .page::after {
-    content: "CSS 2026-01-15 v3";
+    content: "CSS 2026-01-20 v1";
     position: fixed;
     bottom: 5px;
     right: 5px;

--- a/WebUI/Pages/Game.razor.css
+++ b/WebUI/Pages/Game.razor.css
@@ -16,7 +16,7 @@
 
 /* =============================================================================
    CSS VERSION - UPDATE THIS ONE LINE TO CHANGE ALL VERSION STRINGS BELOW
-   Current: CSS 2026-01-15 v3
+   Current: CSS 2026-01-20 v1
    Note: Global version in MainLayout.razor.css; this adds game-specific info
    ============================================================================= */
 

--- a/WebUI/Pages/Home.razor
+++ b/WebUI/Pages/Home.razor
@@ -9,6 +9,29 @@
     <h1>Catan</h1>
     <p class="subtitle">Settlers of Catan - Web Edition</p>
 
+    @if (serverStatus == ServerStatus.Checking || serverStatus == ServerStatus.WarmingUp)
+    {
+        <div class="server-status warming">
+            <i class="fa-solid fa-spinner fa-spin"></i>
+            <span>@statusMessage</span>
+        </div>
+    }
+    else if (serverStatus == ServerStatus.Error)
+    {
+        <div class="server-status error">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+            <span>@statusMessage</span>
+            <button class="retry-button" @onclick="CheckServerHealth">Retry</button>
+        </div>
+    }
+    else if (serverStatus == ServerStatus.Ready)
+    {
+        <div class="server-status ready">
+            <i class="fa-solid fa-check-circle"></i>
+            <span>Server ready</span>
+        </div>
+    }
+
     <div class="menu-options">
         @if (!string.IsNullOrEmpty(GameConnection.GameId))
         {
@@ -223,6 +246,57 @@
         border-radius: 3px;
     }
 
+    .server-status {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        padding: 15px 20px;
+        border-radius: 8px;
+        margin-bottom: 20px;
+        font-size: 1rem;
+    }
+
+    .server-status.warming {
+        background-color: var(--status-warning-bg);
+        border: 1px solid var(--status-warning-border);
+        color: var(--status-warning-text);
+    }
+
+    .server-status.error {
+        background-color: var(--status-error-bg);
+        border: 1px solid var(--status-error-border);
+        color: var(--status-error-text);
+    }
+
+    .server-status.ready {
+        background-color: var(--status-success-bg);
+        border: 1px solid var(--status-success-border);
+        color: var(--status-success-text);
+        animation: fadeOut 3s forwards;
+        animation-delay: 2s;
+    }
+
+    @@keyframes fadeOut {
+        from { opacity: 1; }
+        to { opacity: 0; height: 0; padding: 0; margin: 0; overflow: hidden; }
+    }
+
+    .retry-button {
+        padding: 5px 15px;
+        border: 1px solid var(--status-error-text);
+        border-radius: 4px;
+        background-color: white;
+        color: var(--status-error-text);
+        cursor: pointer;
+        margin-left: 10px;
+    }
+
+    .retry-button:hover {
+        background-color: var(--status-error-text);
+        color: white;
+    }
+
     .troubleshoot-results {
         margin-top: 20px;
         padding: 20px;
@@ -350,6 +424,19 @@
             padding: 20px 40px;
             font-size: 2rem;
         }
+
+        .server-status {
+            padding: 25px 30px;
+            font-size: 2.2rem;
+            border-radius: 16px;
+            margin-bottom: 40px;
+        }
+
+        .retry-button {
+            padding: 15px 30px;
+            font-size: 2rem;
+            border-radius: 8px;
+        }
     }
 
     /* Slightly smaller for very small phones */
@@ -377,6 +464,99 @@
     private bool isTroubleshooting = false;
     private TroubleshootResult? troubleshootResult;
     private string? troubleshootError;
+
+    // Static fields persist across page navigations within the same session
+    private static ServerStatus _cachedServerStatus = ServerStatus.Checking;
+    private static string _cachedStatusMessage = "Checking server status...";
+    private static bool _hasCheckedServer = false;
+
+    private ServerStatus serverStatus = ServerStatus.Checking;
+    private string statusMessage = "Checking server status...";
+
+    private enum ServerStatus { None, Checking, WarmingUp, Ready, Error }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (_hasCheckedServer)
+        {
+            // Use cached result - don't re-check every time
+            serverStatus = _cachedServerStatus;
+            statusMessage = _cachedStatusMessage;
+            // If server was ready, don't show any banner on return visits
+            if (serverStatus == ServerStatus.Ready)
+            {
+                serverStatus = ServerStatus.None;
+            }
+            return;
+        }
+
+        await CheckServerHealth();
+    }
+
+    private async Task CheckServerHealth()
+    {
+        serverStatus = ServerStatus.Checking;
+        statusMessage = "Checking server status...";
+        StateHasChanged();
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var startedWarmingMessage = false;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+
+            // Start a background task to update the message if it takes too long
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(2000); // Wait 2 seconds
+                if (serverStatus == ServerStatus.Checking)
+                {
+                    await InvokeAsync(() =>
+                    {
+                        serverStatus = ServerStatus.WarmingUp;
+                        statusMessage = "Warming up server... (this may take 30-60 seconds on first access)";
+                        startedWarmingMessage = true;
+                        StateHasChanged();
+                    });
+                }
+            });
+
+            var response = await Http.GetAsync($"{GameServiceConfig.BaseUrl}/health", cts.Token);
+
+            stopwatch.Stop();
+
+            if (response.IsSuccessStatusCode)
+            {
+                serverStatus = ServerStatus.Ready;
+                statusMessage = startedWarmingMessage
+                    ? $"Server ready (warmed up in {stopwatch.Elapsed.TotalSeconds:F1}s)"
+                    : "Server ready";
+            }
+            else
+            {
+                serverStatus = ServerStatus.Error;
+                statusMessage = $"Server returned error: {response.StatusCode}";
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            serverStatus = ServerStatus.Error;
+            statusMessage = "Server not responding (timeout after 90s)";
+        }
+        catch (Exception ex)
+        {
+            serverStatus = ServerStatus.Error;
+            statusMessage = $"Cannot reach server: {ex.Message}";
+        }
+
+        // Cache the result for subsequent visits
+        _cachedServerStatus = serverStatus;
+        _cachedStatusMessage = statusMessage;
+        _hasCheckedServer = true;
+
+        StateHasChanged();
+    }
 
     private async Task RunTroubleshoot()
     {

--- a/WebUI/wwwroot/css/app.css
+++ b/WebUI/wwwroot/css/app.css
@@ -50,6 +50,19 @@
     --accent-error: #f44336;
 
     /* ==========================================================================
+       Status Banner Colors (for alerts, notifications, server status)
+       ========================================================================== */
+    --status-warning-bg: #fff3cd;
+    --status-warning-border: #ffeeba;
+    --status-warning-text: #856404;
+    --status-error-bg: #f8d7da;
+    --status-error-border: #f5c6cb;
+    --status-error-text: #721c24;
+    --status-success-bg: #d4edda;
+    --status-success-border: #c3e6cb;
+    --status-success-text: #155724;
+
+    /* ==========================================================================
        Overlay/Transparent Backgrounds
        ========================================================================== */
     --overlay-dark: rgba(0, 0, 0, 0.6);

--- a/WebUI/wwwroot/index.html
+++ b/WebUI/wwwroot/index.html
@@ -22,15 +22,15 @@
     <base href="/" />
     <!-- CSS/JS Cache Busting: Update version query params when CSS/JS changes
          To update all versions at once, run from repo root:
-         sed -i '' 's/2026-01-15-v3/YYYY-MM-DD-vN/g' WebUI/wwwroot/index.html
+         sed -i '' 's/2026-01-20-v1/YYYY-MM-DD-vN/g' WebUI/wwwroot/index.html
          Also update CSS content strings in *.razor.css files (see MainLayout.razor.css) -->
     <!-- Preload Font Awesome font for faster icon rendering -->
     <link rel="preload" href="lib/fontawesome/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="lib/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="lib/fontawesome/fontawesome-solid.css" />
-    <link rel="stylesheet" href="css/app.css?v=2026-01-15-v3" />
+    <link rel="stylesheet" href="css/app.css?v=2026-01-20-v1" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link href="Catan3.WebUI.styles.css?v=2026-01-15-v3" rel="stylesheet" />
+    <link href="Catan3.WebUI.styles.css?v=2026-01-20-v1" rel="stylesheet" />
 
     <!-- Prefetch critical theme assets while WASM loads -->
     <link rel="prefetch" href="themes/base/tiles/brick.png" as="image" />
@@ -69,7 +69,7 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
-    <script src="js/svgRasterizer.js?v=2026-01-15-v3"></script>
+    <script src="js/svgRasterizer.js?v=2026-01-20-v1"></script>
     <script src="js/viewportScaler.js?v=2026-01-14-v1"></script>
     <script src="js/fullscreen.js?v=2026-01-14-v5"></script>
 


### PR DESCRIPTION
## Summary

- **Server warmup indicator**: Home page now shows a status banner during cold starts ("Warming up server...") instead of hanging silently. Shows warmup time when complete, fades after ready.
- **Cached health status**: Health check only runs on first visit per session - subsequent visits don't re-check.
- **Troubleshoot self-healing**: Added Reader (resource group) and SQL Server Contributor roles to install scripts so the Troubleshoot button can actually fix issues like disabled public network access.
- **Deployment design doc**: Added `.design/deployment.md` with staging/production branch strategy using Azure deployment slots.
- **CSS cache busting**: Updated version strings to 2026-01-20-v1.

## Test plan

- [x] Visit https://catan.azurewebsites.net after cold start - should see warmup indicator
- [x] Navigate away and back to Home - should NOT see indicator (cached)
- [x] Click Troubleshoot when server has issues - should be able to fix them
- [x] Verify local dev works with `./catan.ps1 run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)