### PR TITLE
fix: Correct road adjacency geometry for Top edge

### DIFF
--- a/Catan3.Shared/Extensions/RoadModelExtensions.cs
+++ b/Catan3.Shared/Extensions/RoadModelExtensions.cs
@@ -46,10 +46,15 @@ namespace Catan3.Shared.Extensions
                 case HexSide.None:
                     throw new System.Exception($"Roadkey {key} has HexSide=None");
                 case HexSide.Top:
+                    // Top edge connects TopLeft and TopRight vertices
+                    // At TopRight vertex: TopRight (same hex), North.BottomRight (shares vertex)
+                    // At TopLeft vertex: TopLeft (same hex), NorthWest.Bottom (shares vertex)
+                    // NOTE: BottomLeft was incorrect - it doesn't touch TopLeft vertex at all.
+                    // Bottom edge correctly shares TopLeft vertex (= NorthWest's BottomRight vertex)
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey, HexSide = HexSide.TopRight });
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey, HexSide = HexSide.TopLeft });
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey.North, HexSide = HexSide.BottomRight });
-                    adjacentKeys.Add(new RoadKey { TileKey = key.TileKey.NorthWest, HexSide = HexSide.BottomLeft });
+                    adjacentKeys.Add(new RoadKey { TileKey = key.TileKey.NorthWest, HexSide = HexSide.Bottom });
                     break;
                 case HexSide.TopRight:
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey, HexSide = HexSide.BottomRight });

--- a/Catan3.Shared/Extensions/RoadModelExtensions.cs
+++ b/Catan3.Shared/Extensions/RoadModelExtensions.cs
@@ -50,7 +50,7 @@ namespace Catan3.Shared.Extensions
                     // At TopRight vertex: TopRight (same hex), North.BottomRight (shares vertex)
                     // At TopLeft vertex: TopLeft (same hex), NorthWest.Bottom (shares vertex)
                     // NOTE: BottomLeft was incorrect - it doesn't touch TopLeft vertex at all.
-                    // Bottom edge correctly shares TopLeft vertex (= NorthWest's BottomRight vertex)
+                    // Bottom edge correctly shares TopLeft vertex (= NorthWest's TopRight vertex)
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey, HexSide = HexSide.TopRight });
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey, HexSide = HexSide.TopLeft });
                     adjacentKeys.Add(new RoadKey { TileKey = key.TileKey.North, HexSide = HexSide.BottomRight });


### PR DESCRIPTION
## Summary

- Fixes incorrect road adjacency calculation for the Top edge
- `NorthWest.BottomLeft` was geometrically wrong - changed to `NorthWest.Bottom`

## Problem

The Top edge connects TopLeft and TopRight vertices. When finding adjacent roads at the TopLeft vertex, the code incorrectly used `NorthWest.BottomLeft`, which doesn't touch the TopLeft vertex at all.

```
Before: NorthWest.BottomLeft  (wrong - disconnected from vertex)
After:  NorthWest.Bottom      (correct - shares TopLeft vertex)
```

## Impact

This bug could cause incorrect longest road calculations in edge cases where roads meet at the TopLeft vertex of a Top edge.

## Test plan

- [x] Build passes
- [x] Tests.Shared passes (45 tests)
- [ ] Manual: Play a game with roads meeting at affected vertex positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)