### PR TITLE
fix: Eliminate deploy race condition and move slot config to install

### DIFF
--- a/.github/workflows/deploy-react-staging.yml
+++ b/.github/workflows/deploy-react-staging.yml
@@ -1,12 +1,6 @@
-name: Deploy React UI to Staging (from main)
+name: Deploy React UI to Staging (manual)
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'react-ui/**'
-      - '.github/workflows/deploy-react-staging.yml'
   workflow_dispatch:
 
 jobs:

--- a/.scripts/catan-azure.ps1
+++ b/.scripts/catan-azure.ps1
@@ -1831,6 +1831,12 @@ function Install-UI {
         Write-Log -Level "INFO" -Message "Staging slot exists"
     }
 
+    # Configure staging slot for Node.js with anti-Oryx settings (idempotent)
+    # This prevents Kudu from running Oryx builds on pre-built standalone Next.js deployments
+    Write-Log -Level "INFO" -Message "Configuring staging slot for Node.js..."
+    Invoke-AzCommand "webapp config set --name $appName --resource-group $rgName --slot staging --linux-fx-version `"NODE|22-lts`" --startup-file `"node server.js`"" -SuppressOutput
+    Invoke-AzCommand "webapp config appsettings set --name $appName --resource-group $rgName --slot staging --settings WEBSITE_NODE_DEFAULT_VERSION=~22 SCM_DO_BUILD_DURING_DEPLOYMENT=false ENABLE_ORYX_BUILD=false WEBSITES_CONTAINER_START_TIME_LIMIT=600" -SuppressOutput
+
     return $true
 }
 
@@ -2705,10 +2711,8 @@ function Deploy-ReactStaging {
     $zipSize = (Get-Item $zipPath).Length / 1MB
     Write-Log -Level "INFO" -Message "Deploying React UI to staging ($([math]::Round($zipSize, 1)) MB)..."
 
-    # Configure staging slot for Node.js (production slot uses .NET for Blazor)
-    Write-Log -Level "INFO" -Message "Configuring staging slot for Node.js..."
-    Invoke-AzCommand "webapp config set --name $appName --resource-group $rgName --slot staging --linux-fx-version `"NODE|22-lts`" --startup-file `"node server.js`"" -SuppressOutput
-    Invoke-AzCommand "webapp config appsettings set --name $appName --resource-group $rgName --slot staging --settings WEBSITE_NODE_DEFAULT_VERSION=~22 NEXT_PUBLIC_GAME_SERVICE_URL=$gameServiceUrl SCM_DO_BUILD_DURING_DEPLOYMENT=false ENABLE_ORYX_BUILD=false WEBSITES_CONTAINER_START_TIME_LIMIT=600" -SuppressOutput
+    # Set the GameService URL for this deploy (slot config is set at install time by Install-UI)
+    Invoke-AzCommand "webapp config appsettings set --name $appName --resource-group $rgName --slot staging --settings NEXT_PUBLIC_GAME_SERVICE_URL=$gameServiceUrl" -SuppressOutput
 
     # Deploy via Kudu ZIP Deploy API (truly async, unlike az webapp deploy --async true)
     if (-not (Deploy-KuduZip -AppName $appName -ResourceGroup $rgName -ZipPath $zipPath -Slot "staging")) {


### PR DESCRIPTION
## Summary
- Two workflows (`deploy-react-staging` and `deploy-azure`) both triggered on push to main, racing to deploy to the same staging slot — causing 409 Conflict errors and stuck Kudu builds
- Removed push-to-main trigger from `deploy-react-staging.yml` (now manual/workflow_dispatch only)
- Moved Node.js runtime and anti-Oryx settings (`SCM_DO_BUILD_DURING_DEPLOYMENT=false`, `ENABLE_ORYX_BUILD=false`) to `Install-UI` slot creation so they persist across deploys
- `Deploy-ReactStaging` now only sets `NEXT_PUBLIC_GAME_SERVICE_URL` per-deploy (everything else is pre-configured)

## Root cause
Both `deploy-react-staging.yml` and `deploy-azure.yml` triggered at the exact same timestamp on every push to main. They both called `Deploy-ReactStaging` which set app settings + deployed a zip to the same staging slot. One would get a 409 Conflict, the other would find Kudu stuck in "Building" because Oryx settings weren't applied before the deploy started.

## Test plan
- [ ] Merge to main and verify only `deploy-azure.yml` triggers (not `deploy-react-staging.yml`)
- [ ] Verify staging deploy succeeds without 409 Conflict
- [ ] Verify staging app starts and responds to health check
- [ ] Verify slot swap completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)