### PR TITLE
fix: Clear pending roll prefix when leaving WaitingForRoll

### DIFF
--- a/react-ui/app/game/[id]/page.tsx
+++ b/react-ui/app/game/[id]/page.tsx
@@ -419,6 +419,13 @@ export default function GamePage(): React.ReactElement {
   // Keyboard roll: tracks whether "1" was pressed, waiting for second digit (0, 1, 2 → 10, 11, 12)
   const pendingRollPrefixRef = useRef(false);
 
+  // Clear pending "1" when leaving WaitingForRoll (mouse roll, state change, etc.)
+  useEffect(() => {
+    if (gameState !== 'WaitingForRoll') {
+      pendingRollPrefixRef.current = false;
+    }
+  }, [gameState]);
+
   // Helper: Get players with buildings adjacent to a tile coordinate
   // Returns simple { id, name } objects matching Blazor's RobberTarget record
   const getPlayersWithBuildingsOnTile = useCallback(


### PR DESCRIPTION
## Summary

- Clears `pendingRollPrefixRef` whenever `gameState` leaves `WaitingForRoll`
- Prevents stale "1" prefix from leaking across turns (e.g., mouse roll or state change before second digit)
- Follow-up to #25 — fix was merged after PR closed

## Test plan

- [x] Press "1", then roll via mouse click — next WaitingForRoll turn should not misinterpret keys
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)