### PR TITLE
fix: unify tile callback signatures and fix robber menu memoization

### DIFF
--- a/react-ui/app/game/[id]/page.tsx
+++ b/react-ui/app/game/[id]/page.tsx
@@ -492,7 +492,7 @@ export default function GamePage(): React.ReactElement {
 
   // Roughly clamp robber menu position to keep it away from viewport edges.
   // Note: Uses estimated menu dimensions; actual height is dynamic so this is best-effort.
-  const clampRobberMenuPosition = (position: { x: number; y: number }) => {
+  const clampRobberMenuPosition = useCallback((position: { x: number; y: number }) => {
     if (typeof window === 'undefined') {
       return position;
     }
@@ -508,7 +508,7 @@ export default function GamePage(): React.ReactElement {
       x: Math.min(Math.max(position.x, margin), maxX),
       y: Math.min(Math.max(position.y, margin), maxY),
     };
-  };
+  }, []);
 
   // Validate and show robber target menu for a tile click
   const showRobberMenu = useCallback(
@@ -577,8 +577,8 @@ export default function GamePage(): React.ReactElement {
 
   // Right-click handler for robber placement (menu at click position)
   const handleTileRightClick = useCallback(
-    (tile: TileModel, event: React.MouseEvent) => {
-      showRobberMenu(tile, { x: event.clientX, y: event.clientY });
+    (tile: TileModel, clientX: number, clientY: number) => {
+      showRobberMenu(tile, { x: clientX, y: clientY });
     },
     [showRobberMenu]
   );

--- a/react-ui/components/game/board/GameBoard.tsx
+++ b/react-ui/components/game/board/GameBoard.tsx
@@ -91,7 +91,7 @@ export interface GameBoardProps {
    */
   onTileClick?: (tile: TileModel, clientX: number, clientY: number) => void;
   /** Callback when a tile is right-clicked (e.g., robber placement) */
-  onTileRightClick?: (tile: TileModel, event: React.MouseEvent) => void;
+  onTileRightClick?: (tile: TileModel, clientX: number, clientY: number) => void;
   /** Set of highlighted tile keys (for dice roll highlighting) */
   highlightedTiles?: Set<string>;
   /** Callback when a buildable building spot is clicked */
@@ -907,14 +907,7 @@ export function GameBoard({
 
       // Right-click always goes to the tile (robber placement, etc.)
       if (button === 'right') {
-        // Create a real DOM MouseEvent with coordinates for menu positioning
-        const nativeEvent = new MouseEvent('contextmenu', {
-          clientX,
-          clientY,
-          bubbles: true,
-          cancelable: true,
-        });
-        onTileRightClick?.(tile, nativeEvent as unknown as React.MouseEvent);
+        onTileRightClick?.(tile, clientX, clientY);
         return;
       }
 


### PR DESCRIPTION
## Summary

- **Unify `onTileRightClick` signature**: Changed from `(tile, event: React.MouseEvent)` to `(tile, clientX: number, clientY: number)`, matching `onTileClick`. Eliminates fake `MouseEvent` construction and `as unknown as React.MouseEvent` double cast in `dispatchInteraction`.
- **Fix `clampRobberMenuPosition` memoization**: Wrapped in `useCallback(fn, [])` so `showRobberMenu`, `handleTileClick`, and `handleTileRightClick` are properly memoized and not recreated on every render.

## Files changed

| File | Change |
|------|--------|
| `react-ui/components/game/board/GameBoard.tsx` | Updated `onTileRightClick` prop type; replaced fake event construction with direct coord pass-through |
| `react-ui/app/game/[id]/page.tsx` | Wrapped `clampRobberMenuPosition` in `useCallback`; updated `handleTileRightClick` signature |

## Test plan

- [ ] Start a game, trigger `MustMoveRobber` state (roll a 7)
- [ ] Left-click a tile — robber context menu appears at click position
- [ ] Right-click a tile — robber context menu appears at click position
- [ ] Verify menu is clamped away from viewport edges
- [ ] `tsc --noEmit` passes (verified locally)
- [ ] `.NET` build passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)