### PR TITLE
ci: deploy GameService and database to production on backend changes

### DIFF
--- a/.design/cicd-production-gameservice.md
+++ b/.design/cicd-production-gameservice.md
@@ -1,0 +1,119 @@
+# Design: Production CI/CD — GameService + Database Deploy
+
+## Problem
+
+`deploy-azure.yml` (triggered on push to `main`) only deploys the React UI.
+It never builds or deploys the ASP.NET GameService or ensures database access.
+As a result, the production GameService has been stale since ~Feb 2026 (commit
+`21b29d4`) despite many merges to `main`.
+
+`deploy-staging.yml` does the right thing — it uses change detection and deploys
+the backend or frontend independently. Production needs the same treatment.
+
+## Current State
+
+| Workflow | Trigger | Deploys |
+|---|---|---|
+| `deploy-staging.yml` | push to `staging` | GameService → staging API slot (if backend changed), React → staging UI slot (if frontend changed), DB access grant |
+| `deploy-azure.yml` | push to `main` | React UI only (staging slot → slot swap to production) |
+
+## Proposed Solution
+
+Extend `deploy-azure.yml` to mirror the structure of `deploy-staging.yml`:
+
+1. **Add a `changes` job** — identical change detection logic (backend = `Catan3.GameService/` or `Catan3.Shared/`; frontend = `react-ui/`; `workflow_dispatch` deploys everything).
+2. **Add a `deploy-gameservice` job** — runs `catan-azure.ps1 game-service deploy -Force` (no `-Slot` = production slot). Skips when no backend changes.
+3. **Add a `deploy-database` job** — runs `catan-azure.ps1 database deploy` after GameService deploys. This is idempotent — it verifies the connection string and managed identity are configured. Skips when no backend changes.
+4. **Keep the React jobs** — gate them on `frontend == 'true'` rather than always running.
+
+## Key Design Decisions
+
+### GameService: direct deploy, no slot swap
+
+The React UI uses a blue-green slot swap (staging slot → production). The
+GameService does not have a staging slot in the production pipeline. This is
+acceptable because:
+
+- The GameService API is versioned and backwards-compatible by convention
+- A direct deploy with restart causes ~30s downtime, acceptable for this project
+- Adding a GameService staging slot would require schema migration coordination
+  and significant complexity
+
+If zero-downtime GameService deploys become a requirement, that's a separate
+design effort.
+
+### Database: idempotent deploy, not install
+
+`database deploy` checks if the connection string and managed identity are
+already configured before acting. Running it on every backend deploy is safe.
+It should NOT run `database install` (which provisions infrastructure).
+
+`database deploy-staging-access` (used in staging) grants the staging slot
+identity access to the shared database. That is staging-specific and not needed
+here — production's managed identity already has access from initial install.
+
+### Change detection scope
+
+Backend path filter: `^(Catan3\.GameService|Catan3\.Shared)/`
+
+This is identical to staging. Any change to shared game logic or the service
+itself triggers a backend redeploy.
+
+### React deploy: only when frontend changed
+
+Currently `deploy-azure.yml` always deploys React on every push to `main`,
+even if only backend files changed. With change detection, a pure backend
+change won't trigger a React build/deploy/swap. This is a secondary benefit.
+
+### `workflow_dispatch` forces all
+
+On manual trigger, deploy everything regardless of detected changes.
+
+## Revised Workflow Structure
+
+```
+push to main
+    │
+    ▼
+changes (detect backend/frontend)
+    │
+    ├──► deploy-gameservice  (if backend=true)
+    │        └──► deploy-database  (after gameservice)
+    │
+    ├──► deploy-react  (if frontend=true)
+    │        ├── build React
+    │        ├── deploy to staging slot
+    │        ├── verify staging slot
+    │        ├── swap slots
+    │        └── verify production
+    │
+    └──► verify (summary, always runs)
+```
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `.github/workflows/deploy-azure.yml` | Add `changes` job, `deploy-gameservice` job, `deploy-database` job; gate React on `frontend=true` |
+
+No changes needed to `.scripts/catan-azure.ps1` — the existing
+`game-service deploy` and `database deploy` commands already support production
+(no `-Slot` argument = production slot).
+
+## Health Verification
+
+After GameService deploy, poll `https://catan-api.azurewebsites.net/health`
+until `status == "healthy"` (same pattern as staging's 10-minute poll loop).
+
+After React slot swap, existing verify-production step is unchanged.
+
+## Risks
+
+- **GameService deploy downtime**: ~30s restart window. Acceptable.
+- **`appsettings set` race**: As seen in staging, if two jobs call
+  `appsettings set` on the same slot concurrently they can conflict.
+  In this design the database job runs sequentially _after_ the GameService
+  job so they don't race each other. The React job runs in parallel but
+  targets a different Azure resource so no conflict.
+- **First run**: The first time this runs, `game-service deploy` will
+  deploy the current `main` HEAD, resolving the stale `21b29d4` issue.

--- a/.design/implementation-plans/cicd-production-gameservice-plan.md
+++ b/.design/implementation-plans/cicd-production-gameservice-plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan: Production CI/CD — GameService + Database
+
+**Design doc:** `.design/cicd-production-gameservice.md`
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `.github/workflows/deploy-azure.yml` | Full rewrite — add `changes`, `deploy-gameservice`, `deploy-database` jobs; gate React on `frontend=true`; add `verify` summary job |
+
+## Per-Job Changes
+
+### New: `changes` job
+
+Identical to `deploy-staging.yml` `changes` job.
+Outputs: `backend`, `frontend` booleans.
+Path filters:
+- backend: `^(Catan3\.GameService|Catan3\.Shared)/`
+- frontend: `^react-ui/`
+- `workflow_dispatch` → force both true.
+
+### New: `deploy-gameservice` job
+
+- `needs: changes`, `if: needs.changes.outputs.backend == 'true'`
+- Requires `.NET 9`, Azure login
+- Step: `catan-azure.ps1 game-service deploy -Force -TraceLevel INFO` (no `-Slot` = production)
+- Step: poll `https://catan-api.azurewebsites.net/health` for `status == "healthy"` — 60 × 10s (10 min max), same pattern as staging
+
+### New: `deploy-database` job
+
+- `needs: [changes, deploy-gameservice]`, `if: needs.changes.outputs.backend == 'true'`
+- Requires Azure login only (no .NET)
+- Step: `catan-azure.ps1 database deploy -TraceLevel INFO`
+- No health poll needed — `database deploy` is synchronous and self-verifying
+
+### Modified: React deploy job (renamed `deploy` → `deploy-react`)
+
+- Add `needs: changes`, `if: needs.changes.outputs.frontend == 'true'`
+- All existing steps unchanged (build → staging slot deploy → verify staging → swap → verify production)
+
+### New: `verify` summary job
+
+- `needs: [changes, deploy-gameservice, deploy-react, deploy-database]`
+- `if: always() && !cancelled()`
+- Prints what was deployed, hits both health endpoints, prints rollback command
+
+## Verification Steps
+
+1. Merge a backend-only change to `main` → only `deploy-gameservice` + `deploy-database` should run; React job should be skipped.
+2. Merge a frontend-only change to `main` → only `deploy-react` should run; GameService jobs should be skipped.
+3. `workflow_dispatch` → all three deploy jobs should run.
+4. After step 1, `pwsh ./catan.ps1 azure doctor` should show game-service at current commit, status OK.

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -7,8 +7,119 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  # Detect which components changed so we only deploy what's needed
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - id: filter
+        run: |
+          # Compare with parent commit to detect changed paths
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # Backend: GameService or Shared code changes
+          if echo "$CHANGED" | grep -qE '^(Catan3\.GameService|Catan3\.Shared)/'; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Frontend: React UI changes
+          if echo "$CHANGED" | grep -qE '^react-ui/'; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # On workflow_dispatch, deploy everything
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-gameservice:
+    name: Deploy GameService (production)
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy GameService to production
+        shell: pwsh
+        run: |
+          ./.scripts/catan-azure.ps1 game-service deploy -Force -TraceLevel INFO
+
+      - name: Verify GameService production health
+        run: |
+          echo "Waiting for GameService production to start..."
+          for i in $(seq 1 60); do
+            RESPONSE=$(curl -sf -m 10 \
+              https://catan-api.azurewebsites.net/health 2>/dev/null || echo "")
+            if [ -n "$RESPONSE" ]; then
+              STATUS=$(echo "$RESPONSE" | jq -r '.status' 2>/dev/null || echo "")
+              if [ "$STATUS" = "healthy" ]; then
+                echo "GameService production healthy after $((i*10))s"
+                echo "$RESPONSE" | jq .
+                exit 0
+              fi
+            fi
+            echo "GameService production ($((i*10))s): waiting..."
+            sleep 10
+          done
+          echo "::error::GameService production did not become healthy within 10 minutes"
+          exit 1
+
+  deploy-database:
+    name: Ensure database access (production)
+    needs: [changes, deploy-gameservice]
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify database access
+        shell: pwsh
+        run: |
+          ./.scripts/catan-azure.ps1 database deploy -TraceLevel INFO
+
+  deploy-react:
     name: Deploy React + Swap
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -75,11 +186,26 @@ jobs:
           echo "::warning::Production did not respond within 3 minutes after swap"
           exit 1
 
-      - name: Summary
-        if: always()
+  verify:
+    name: Verify production
+    needs: [changes, deploy-gameservice, deploy-react, deploy-database]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Production summary
         run: |
-          echo "=== Deployment Summary ==="
-          echo "Production: https://catan.azurewebsites.net"
-          echo "Staging:    https://catan-staging.azurewebsites.net (rollback)"
+          echo "=== Production Deployment Summary ==="
           echo ""
-          echo "To rollback: az webapp deployment slot swap --name catan --resource-group rg-catan --slot staging --target-slot production"
+          echo "Backend deployed: ${{ needs.changes.outputs.backend }}"
+          echo "Frontend deployed: ${{ needs.changes.outputs.frontend }}"
+          echo ""
+          echo "=== Production URLs ==="
+          echo "React UI:    https://catan.azurewebsites.net"
+          echo "GameService: https://catan-api.azurewebsites.net"
+          echo ""
+          echo "=== Health Check ==="
+          curl -sf https://catan-api.azurewebsites.net/health | jq . || echo "GameService not responding"
+          echo ""
+          curl -sf -o /dev/null -w "React UI: HTTP %{http_code}\n" https://catan.azurewebsites.net || echo "React UI not responding"
+          echo ""
+          echo "To rollback React: az webapp deployment slot swap --name catan --resource-group rg-catan --slot staging --target-slot production"


### PR DESCRIPTION
## Summary

- `deploy-azure.yml` previously only deployed the React UI on push to `main`, leaving the GameService stale indefinitely (currently at commit `21b29d4` from ~Feb 2026)
- Added change detection matching `deploy-staging.yml`: backend triggers on `Catan3.GameService/` or `Catan3.Shared/` changes, frontend on `react-ui/`
- Added `deploy-gameservice` job: builds and deploys ASP.NET GameService directly to production slot, then polls `/health` for up to 10 minutes
- Added `deploy-database` job: runs `database deploy` (idempotent — verifies connection string + managed identity) after GameService deploys
- `deploy-react` job now only runs when frontend files change; `workflow_dispatch` forces all three
- Added `verify` summary job that always runs and hits both health endpoints

## Test plan

- [ ] Merge this PR — `workflow_dispatch` trigger manually to verify all three deploy jobs run
- [ ] After deploy, `pwsh ./catan.ps1 azure doctor` should show game-service at current commit with status OK
- [ ] Make a backend-only change → only `deploy-gameservice` + `deploy-database` should run
- [ ] Make a frontend-only change → only `deploy-react` should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)