### PR TITLE
fix: compare deployed commit against origin/main in doctor

### DIFF
--- a/.scripts/catan-azure.ps1
+++ b/.scripts/catan-azure.ps1
@@ -2090,8 +2090,14 @@ function Get-GitHubDoctor {
 #>
 function Get-GitCommitHash {
     try {
-        $hash = git -C $ProjectRoot rev-parse --short HEAD 2>$null
-        return $hash.Trim()
+        # Compare against origin/main (what CI/CD deploys) rather than the
+        # checked-out HEAD, so the doctor doesn't report NEEDS DEPLOY when
+        # the user is simply on a feature branch.
+        $hash = git -C $ProjectRoot rev-parse --short origin/main 2>$null
+        if ([string]::IsNullOrWhiteSpace($hash)) { return "unknown" }
+        # rev-parse always returns one line; Select-Object guards against
+        # edge cases where $hash is an array, which would cause .Trim() to throw.
+        return ($hash | Select-Object -First 1).Trim()
     }
     catch {
         return "unknown"


### PR DESCRIPTION
## Summary

- `Get-GitCommitHash` used `HEAD` (the checked-out local branch) to determine the "current" commit, then compared it against what's deployed on Azure. If the user was on any branch other than main, this always showed a false `NEEDS DEPLOY` / `current: unknown`.
- Changed to `origin/main` so the comparison reflects what CI/CD actually deploys.
- Added null/array guard before `.Trim()` to prevent the catch block returning `"unknown"` under `$ErrorActionPreference = "Stop"` (PS 7.4+ native command behavior).

## Test plan

- [ ] Run `pwsh ./catan.ps1 azure doctor` while on a feature branch — `game-service` and `ui` should show `MATCH` with current `origin/main` commit
- [ ] Run `pwsh ./catan.ps1 azure doctor` while on `main` — same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)