### PR TITLE
feat: show ResourcesThisGame in player panel after game over

### DIFF
--- a/.design/game-over-resources-display.md
+++ b/.design/game-over-resources-display.md
@@ -1,0 +1,38 @@
+# Design: Show ResourcesThisGame on Game Over
+
+## Problem
+
+After a winner is declared (`GameOver` state), the Players panel shows
+`ResourcesThisTurn` (empty after the last roll). This wastes the panel —
+`ResourcesThisGame` is already available on every `PlayerModel` and
+tells the full story of the game.
+
+## Solution
+
+In `PlayersPanel.tsx`, the `PlayerTile` component already reads
+`player.resourcesThisTurn?.[type]` per resource card. Change the
+source to `player.resourcesThisGame` when `gameState === 'GameOver'`.
+
+```
+const isGameOver = gameState === 'GameOver';
+const count = isGameOver
+  ? player.resourcesThisGame?.[type] ?? 0
+  : player.resourcesThisTurn?.[type] ?? 0;
+```
+
+Add a label above the resource row ("Resources This Game" vs the normal
+unlabelled turn display) so players know what they're looking at.
+
+## Scope
+
+- **One file changed:** `react-ui/components/game/panels/PlayersPanel.tsx`
+- Add `useGameState()` hook call inside `PlayerTile`
+- Swap resource source when `GameOver`
+- Add conditional label text
+
+## What stays the same
+
+- `ResourceCard` component — no changes
+- `RESOURCE_CARD_CONFIG` — no changes
+- `autoFlip` behaviour — cards still animate in
+- All other game states — no change to existing behaviour

--- a/react-ui/components/game/panels/PlayersPanel.tsx
+++ b/react-ui/components/game/panels/PlayersPanel.tsx
@@ -17,7 +17,7 @@ import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { useAssetPath } from '@/lib/theme';
 import type { AssetName } from '@/lib/theme/types';
 import type { PlayerModel } from '@/types/generated/models/player-model';
-import { usePlayers, useCurrentTurnPlayerId, usePlayerProfiles } from '@/lib/stores/gameStoreHooks';
+import { usePlayers, useCurrentTurnPlayerId, usePlayerProfiles, useGameState } from '@/lib/stores/gameStoreHooks';
 import { getServiceUrl } from '@/lib/config';
 import {
   createPlayerColorsWithGradient,
@@ -239,6 +239,8 @@ interface PlayerTileProps {
 
 const PlayerTile = memo(function PlayerTile({ player, profile, isCurrentPlayer }: PlayerTileProps) {
   const colors = createColorsFromProfile(profile);
+  const gameState = useGameState();
+  const isGameOver = gameState === 'GameOver';
 
   // Count from spentEntitlementsThisGame - these are placed items
   const spentEntitlements = player.spentEntitlementsThisGame ?? [];
@@ -344,10 +346,14 @@ const PlayerTile = memo(function PlayerTile({ player, profile, isCurrentPlayer }
         </div>
       </div>
 
-      {/* Row 2: Resources This Turn */}
-      <div className="flex gap-0.5 mt-1">
+      {/* Row 2: Resources This Turn (or This Game on GameOver) */}
+      <div className="flex gap-0.5 mt-1 items-center">
+        {isGameOver && (
+          <span className="text-xs text-white/50 mr-0.5 whitespace-nowrap">Game:</span>
+        )}
         {RESOURCE_CARD_CONFIG.map(({ type }) => {
-          const count = player.resourcesThisTurn?.[type] ?? 0;
+          const source = isGameOver ? player.resourcesThisGame : player.resourcesThisTurn;
+          const count = source?.[type] ?? 0;
           const hasHarbor =
             type !== 'goldMine' && type !== 'robber' && ownedHarbors.includes(type as OwnedHarbor);
           return (


### PR DESCRIPTION
## Summary

- After `GameOver` is declared, the per-player resource row in the Players panel switches from `ResourcesThisTurn` (empty) to `ResourcesThisGame` so everyone can review the full game totals
- A small **Game:** label appears to distinguish totals from the normal per-turn display
- All other game states are unchanged

## Change

One file: `react-ui/components/game/panels/PlayersPanel.tsx`
- Added `useGameState()` hook to `PlayerTile`
- Source swapped: `isGameOver ? player.resourcesThisGame : player.resourcesThisTurn`
- Conditional "Game:" label prefix

## Test plan

- [x] Manually tested — resource totals display correctly after declaring a winner
- [ ] Verify on staging: start game → declare winner → confirm resource row shows game totals with "Game:" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)