### PR TITLE
fix: pass isGameOver prop to PlayerTile from parent

### DIFF
--- a/react-ui/components/game/panels/PlayersPanel.tsx
+++ b/react-ui/components/game/panels/PlayersPanel.tsx
@@ -17,7 +17,7 @@ import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { useAssetPath } from '@/lib/theme';
 import type { AssetName } from '@/lib/theme/types';
 import type { PlayerModel } from '@/types/generated/models/player-model';
-import { usePlayers, useCurrentTurnPlayerId, usePlayerProfiles } from '@/lib/stores/gameStoreHooks';
+import { usePlayers, useCurrentTurnPlayerId, usePlayerProfiles, useGameState } from '@/lib/stores/gameStoreHooks';
 import { getServiceUrl } from '@/lib/config';
 import {
   createPlayerColorsWithGradient,
@@ -389,6 +389,8 @@ function ScaledPlayersList() {
   const players = usePlayers();
   const currentPlayerId = useCurrentTurnPlayerId();
   const playerProfiles = usePlayerProfiles();
+  const gameState = useGameState();
+  const isGameOver = gameState === 'GameOver';
 
   // Measure content and container, compute scale to fit
   useEffect(() => {
@@ -438,6 +440,7 @@ function ScaledPlayersList() {
             player={player}
             profile={playerProfiles.get(player.id)}
             isCurrentPlayer={player.id === currentPlayerId}
+            isGameOver={isGameOver}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

Promotes fix from PR #48 to production.

`isGameOver` was added as a required prop to `PlayerTile` (PR #46) but
the parent `ScaledPlayersList` never passed it — so the game-over
resource display never actually triggered. This adds `useGameState()`
to the parent and passes `isGameOver={isGameOver}` to each `PlayerTile`.

## Test plan

- [x] Staging deploy passed (PR #48)
- [ ] Verify on production: declare winner → resource row shows game totals with "Game:" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)