### PR TITLE
fix: CI/CD pipelines + .gitignore for CosmosDB migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet test Tests/Shared -c Release --no-build
-          dotnet test Tests/GameService -c Release --no-build
+          # Skip CatanDb contract tests in CI (require Cosmos emulator or Azure)
+          # Run them locally via: ./catan.ps1 database test [-Azure]
+          dotnet test Tests/GameService -c Release --no-build --filter "FullyQualifiedName!~CatanDb"
           # Note: Tests/Desktop requires a GUI and can only run locally

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Verify database access
         shell: pwsh
         run: |
-          ./.scripts/catan-azure.ps1 database deploy -TraceLevel INFO
+          pwsh .scripts/database.ps1 deploy -Azure -TraceLevel INFO
 
   deploy-react:
     name: Deploy React + Swap

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Grant staging slot database access
         shell: pwsh
         run: |
-          ./.scripts/catan-azure.ps1 database deploy-staging-access -TraceLevel INFO
+          pwsh .scripts/database.ps1 deploy -Azure -TraceLevel INFO
 
   deploy-react:
     name: Deploy React UI (staging)


### PR DESCRIPTION
## Summary

- Update deploy-azure.yml and deploy-staging.yml to use database.ps1 instead of catan-azure.ps1
- Skip CatanDb contract tests in CI (require Cosmos emulator)
- Add .code-reviews to .gitignore
- Markdown lint fixes and remove unused onCopy prop
- Fix last SQLite remnants (#57, #58)

Follow-up to PR #74 (main migration). These changes must land on staging before PR #75 (staging → main) is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)