### PR TITLE
fix: CI/CD pipeline fixes for CosmosDB slot support (#77-80)

### DIFF
--- a/.ai/sessions/SESSION_SUMMARY-2026-03-23-cosmos-migration.md
+++ b/.ai/sessions/SESSION_SUMMARY-2026-03-23-cosmos-migration.md
@@ -1,0 +1,157 @@
+# Session Summary - 2026-03-23 CosmosDB Migration
+
+**Session Duration:** ~8 hours (across multiple sub-sessions)
+**Build Status:** All projects building (1 warning: CS8604 nullable in GameApiController)
+**Test Status:** 27/27 CatanDb contract tests passing, 76 shared tests passing
+**Branch:** cosmos-migration (merged to staging via PRs #74, #76)
+
+## Work Completed
+
+### CosmosDB Data Layer
+
+- **ICatanDb abstraction** — New database interface replacing EF Core `CatanDbContext`
+  - 5 containers: players, games, completed-games, templates, recordings
+  - All CRUD operations, image storage, game archival
+  - Key file: `Catan3.GameService/Abstractions/ICatanDb.cs`
+
+- **CosmosCatanDb implementation** — Full CosmosDB implementation using .NET SDK
+  - Flattened document model (no embedded JSON strings)
+  - `PlayerDoc` has first-class `name`, `colors`, `imageUri`, `imageData` fields
+  - `DefaultAzureCredential` for Azure, emulator key for local dev
+  - Auto-detects local vs Azure via `WEBSITE_SITE_NAME` env var
+  - Key file: `Catan3.GameService/Abstractions/CosmosCatanDb.cs`
+
+- **27 contract tests** — Full coverage of ICatanDb contract
+  - Run against both local Cosmos emulator and Azure CosmosDB
+  - Key files: `Tests/GameService/CatanDb/CatanDbContractTests.cs`,
+    `Tests/GameService/CatanDb/CosmosCatanDbTests.cs`
+
+### Seed Pipeline
+
+- **Flattened player JSON documents** — 7 player files are exact CosmosDB documents
+  - No transformation at insert time; seed script loops and inserts verbatim
+  - `encode-images.ps1` embeds base64 images into JSON files
+  - Key directory: `Catan3.GameService/Default Data/Players/`
+
+- **Recording seed data** — 5 `.catan_test` files converted to JSON and seeded
+  - Key directory: `Catan3.GameService/Default Data/Recordings/`
+
+- **Switched from REST API to .NET SDK** — Eliminated partition key header issues
+  - REST API `x-ms-partitionkey` header returned "fewer components" error on every write
+  - Root cause never fully determined; SDK handles partition keys internally
+  - Load Cosmos SDK DLLs from GameService build output into PowerShell
+
+### database.ps1 Script (1858 lines)
+
+- **Full CosmosDB lifecycle management:**
+  - `install` — Pull emulator image, create containers, seed data (local)
+  - `install -Azure` — Create account, database, containers, RBAC, firewall, seed
+  - `deploy -Azure` — Grant Managed Identity RBAC roles
+  - `seed-data` / `seed-data -Azure` — Insert default data via SDK
+  - `doctor` / `doctor -Azure` — Health checks with status reporting
+  - `test` / `test -Azure` — Run 27 contract tests
+  - `nuke-containers` — Delete and recreate all containers
+
+- **Doctor-driven install:** `Get-AzureDoctorResult` returns hashtable driving all decisions
+  - Firewall check: `publicNetworkAccess=Enabled` + empty ipRules
+  - RBAC probe via SDK (not REST) to verify write access before seeding
+
+### GameService Wiring
+
+- **All controllers/services rewired to ICatanDb:**
+  - `GameApiController` — player CRUD, game save/load, image upload/download
+  - `RecordingController` — recording list/load/delete
+  - `StatsController` — completed games stats
+  - `GameTemplateService` — template CRUD
+  - `DatabasePersistenceService` — game auto-save
+  - `DatabaseSeedingService` — startup initialization
+
+- **Dead code removed:**
+  - `CatanDbContext.cs`, `DatabaseProviderDetector.cs`, `AzureSqlDiagnosticService.cs` deleted
+  - Stale EF Core NuGet packages removed from .csproj
+  - Dead `using` statements cleaned from Program.cs, GameApiController.cs
+  - SQLite functions removed from catan.ps1
+
+### CI/CD Updates
+
+- **deploy-azure.yml / deploy-staging.yml** — Use `database.ps1` instead of old `catan-azure.ps1`
+- **CI test filter** — Skip CatanDb contract tests in CI (require Cosmos emulator)
+- **.code-reviews to .gitignore** — Review artifacts not tracked in git
+
+## Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| SDK over REST API | REST partition key header broken; SDK handles internally |
+| Flattened documents | CosmosDB best practice; queryable/indexable fields |
+| JSON files = CosmosDB docs | No transformation at seed time; single source of truth |
+| encode-images.ps1 separate | Image encoding is a build step, not a runtime step |
+| DefaultAzureCredential | No secrets in config; Managed Identity on Azure |
+| disableLocalAuth=true | AAD-only auth on CosmosDB account |
+| No DatabaseSeedingService work | Templates will become seed data JSON files (future) |
+| Config-as-code over env vars | Detect environment, read config; avoid env var dependencies |
+
+## Bugs Found During Firewall/Partition Key Investigation
+
+- **HTTP 403 firewall:** `publicNetworkAccess: "Disabled"` overrides all ipRules
+  - Fix: `az cosmosdb update --public-network-access Enabled --ip-range-filter ""`
+  - Corporate proxy egress IPs differ from `api.ipify.org` — IP allow-lists unreliable
+
+- **HTTP 400 "fewer components":** Every REST write to CosmosDB failed
+  - All partition key header formats tried (`["value"]`, `"value"`, bare, empty)
+  - Management plane showed correct single-path `/id` definition
+  - Root cause undetermined; switching to .NET SDK resolved it completely
+
+## Code Reviews
+
+- **Claude review:** 3 critical, 5 important, 5 suggestions across 73 files
+- **Copilot review:** File-by-file reviews in `.code-reviews/cosmos-migration/cp/`
+- **Cross-verified:** Issues agreed by both reviewers filed as GitHub issues
+- Review output: `.code-reviews/cosmos-migration/claude/` and `.code-reviews/cosmos-migration/cp/`
+
+## Open Issues Filed
+
+| # | Title | Priority |
+|---|-------|----------|
+| 57 | Remove SQLite functions from catan.ps1 | Must fix |
+| 58 | Remove dead using from GameApiController | Must fix |
+| 60 | Guard debug console.log in React | Soon |
+| 61 | Replace Console.WriteLine with ILogger | Soon |
+| 62 | SELECT projection to exclude imageData | Soon |
+| 63 | Health endpoint lightweight query | Soon |
+| 64 | GameTemplateService point read | Soon |
+| 65 | Document DeletePlayerAsync cascade | Soon |
+| 67 | SaveTemplateAsync mutates caller data | Soon |
+| 77 | Staging missing Cosmos app settings | CI/CD |
+| 78 | Staging identity missing RBAC role | CI/CD |
+| 79 | Deploy skips GameService on workflow changes | CI/CD |
+| 80 | RBAC assignments not idempotent | CI/CD |
+| 81 | React renders raw HTML error page | UX |
+
+## PRs
+
+| # | Title | Status |
+|---|-------|--------|
+| 74 | CosmosDB migration (cosmos-migration → staging) | Merged |
+| 75 | CosmosDB migration (staging → main) | Open |
+| 76 | CI/CD fixes for CosmosDB (cosmos-migration → staging) | Merged |
+
+## Architecture Diagram
+
+```text
+React UI (Next.js)
+    ↓ REST + SignalR
+GameApiController / RecordingController / StatsController
+    ↓ ICatanDb
+CosmosCatanDb (.NET SDK)
+    ↓ DefaultAzureCredential (Azure) / Emulator Key (local)
+Azure CosmosDB / Local Emulator
+```
+
+## Next Steps
+
+1. Fix remaining must-fix issues (#57, #58)
+2. Fix CI/CD issues (#77-80) so staging deploys correctly
+3. Merge PR #75 to main after staging validation
+4. Convert templates from C# code to seed JSON files (use CLI to extract from .catan files)
+5. Remove DatabaseSeedingService entirely once templates are seeded via database.ps1

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -26,8 +26,8 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          # Backend: GameService or Shared code changes
-          if echo "$CHANGED" | grep -qE '^(Catan3\.GameService|Catan3\.Shared)/'; then
+          # Backend: GameService, Shared, or infrastructure script changes
+          if echo "$CHANGED" | grep -qE '^(Catan3\.GameService|Catan3\.Shared|\.scripts|\.azure)/'; then
             echo "backend=true" >> "$GITHUB_OUTPUT"
           else
             echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,8 +25,8 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          # Backend: GameService or Shared code changes
-          if echo "$CHANGED" | grep -qE '^(Catan3\.GameService|Catan3\.Shared)/'; then
+          # Backend: GameService, Shared, or infrastructure script changes
+          if echo "$CHANGED" | grep -qE '^(Catan3\.GameService|Catan3\.Shared|\.scripts|\.azure)/'; then
             echo "backend=true" >> "$GITHUB_OUTPUT"
           else
             echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.scripts/database.ps1
+++ b/.scripts/database.ps1
@@ -986,42 +986,42 @@ function Deploy-AzureDatabase {
     $rg      = $Config.resourceGroup
     $appName = $Config.gameService.appName
 
-    # 1. Set COSMOS_ENDPOINT app setting
-    Write-Log -Level "INFO" -Message "Setting COSMOS_ENDPOINT on App Service '$appName'..."
+    # 1. Set COSMOS_ENDPOINT and COSMOS_DATABASE on production slot
+    Write-Log -Level "INFO" -Message "Setting Cosmos app settings on '$appName' (production)..."
     $null = Invoke-Azure webapp config appsettings set `
         --name $appName `
         --resource-group $rg `
-        --settings "COSMOS_ENDPOINT=$Endpoint" `
+        --settings "COSMOS_ENDPOINT=$Endpoint" "COSMOS_DATABASE=$DatabaseName" `
         --output none
     if ($LASTEXITCODE -ne 0) {
-        Write-Log -Level "ERROR" -Message "Failed to set COSMOS_ENDPOINT app setting."
+        Write-Log -Level "ERROR" -Message "Failed to set Cosmos app settings on production."
         return $false
     }
 
-    # 3. Get managed identity principal ID
-    Write-Log -Level "INFO" -Message "Retrieving managed identity for '$appName'..."
-    $principalId = Invoke-Azure webapp identity show `
+    # 2. Set Cosmos app settings on all deployment slots
+    $slotsJson = Invoke-Azure webapp deployment slot list `
         --name $appName `
         --resource-group $rg `
-        --query principalId `
-        --output tsv
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($principalId)) {
-        Write-Log -Level "WARN" -Message "Managed identity not found — assigning one..."
-        $null = Invoke-Azure webapp identity assign --name $appName --resource-group $rg --output none
-        $principalId = Invoke-Azure webapp identity show `
+        --query "[].name" `
+        --output json
+    $slots = if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($slotsJson)) {
+        ($slotsJson | ConvertFrom-Json)
+    } else { @() }
+
+    foreach ($slot in $slots) {
+        Write-Log -Level "INFO" -Message "Setting Cosmos app settings on slot '$slot'..."
+        $null = Invoke-Azure webapp config appsettings set `
             --name $appName `
             --resource-group $rg `
-            --query principalId `
-            --output tsv
+            --slot $slot `
+            --settings "COSMOS_ENDPOINT=$Endpoint" "COSMOS_DATABASE=$DatabaseName" `
+            --output none
         if ($LASTEXITCODE -ne 0) {
-            Write-Log -Level "ERROR" -Message "Failed to get managed identity principal ID."
-            return $false
+            Write-Log -Level "WARN" -Message "Failed to set Cosmos app settings on slot '$slot'."
         }
     }
-    $principalId = $principalId.Trim()
-    Write-Log -Level "DEBUG" -Message "Principal ID: $principalId"
 
-    # 4. Get Cosmos account resource ID (scope for all role assignments)
+    # 3. Get Cosmos account resource ID (scope for all role assignments)
     $accountId = Invoke-Azure cosmosdb show `
         --name $AccountName `
         --resource-group $rg `
@@ -1033,38 +1033,100 @@ function Deploy-AzureDatabase {
     }
     $accountId = $accountId.Trim()
 
-    # 5+6. Grant role to App Service MI and signed-in developer
-    $developerOid = (Invoke-Azure ad signed-in-user show --query id --output tsv).Trim()
+    # 4. Collect all principals that need RBAC: production MI, slot MIs, developer
+    $principals = @()
 
-    $principals = @( @{ Id = $principalId; Label = "App Service managed identity" } )
-    if (-not [string]::IsNullOrWhiteSpace($developerOid)) {
-        $principals += @{ Id = $developerOid; Label = "signed-in developer ($developerOid)" }
+    # Production managed identity
+    $prodPrincipal = Get-OrAssignManagedIdentity -AppName $appName -ResourceGroup $rg
+    if ($prodPrincipal) {
+        $principals += @{ Id = $prodPrincipal; Label = "production managed identity" }
     }
 
-    Write-Log -Level "INFO" -Message "Granting data contributor role..."
+    # Slot managed identities
+    foreach ($slot in $slots) {
+        $slotPrincipal = Get-OrAssignManagedIdentity -AppName $appName -ResourceGroup $rg -Slot $slot
+        if ($slotPrincipal) {
+            $principals += @{ Id = $slotPrincipal; Label = "slot '$slot' managed identity" }
+        }
+    }
+
+    # Signed-in developer
+    $developerOid = (Invoke-Azure ad signed-in-user show --query id --output tsv 2>$null)
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($developerOid)) {
+        $principals += @{ Id = $developerOid.Trim(); Label = "signed-in developer" }
+    }
+
+    # 5. Grant RBAC to each principal (idempotent — skips if already assigned)
+    Write-Log -Level "INFO" -Message "Granting data contributor role to $($principals.Count) principals..."
     foreach ($p in $principals) {
-        Write-Log -Level "INFO" -Message "  Granting to $($p.Label)..."
+        Write-Log -Level "INFO" -Message "  Granting to $($p.Label) ($($p.Id))..."
         $ok = Grant-CosmosRbac -AccountName $AccountName -ResourceGroup $rg `
                                -PrincipalId $p.Id -Scope $accountId
         if (-not $ok) {
             Write-Log -Level "ERROR" -Message "  RBAC grant failed: $($p.Label)"
             return $false
         }
-        Write-Log -Level "INFO" -Message "  RBAC granted: $($p.Label)"
     }
 
-    Write-Log -Level "INFO" -Message "App Service '$appName' configured for CosmosDB."
+    Write-Log -Level "INFO" -Message "App Service '$appName' (+ $($slots.Count) slots) configured for CosmosDB."
     return $true
 }
 
 <#
 .SYNOPSIS
+    Gets (or assigns) a managed identity for an App Service or slot.
+    Returns the principal ID, or $null on failure.
+#>
+function Get-OrAssignManagedIdentity {
+    param([string]$AppName, [string]$ResourceGroup, [string]$Slot)
+
+    $slotArgs = if ($Slot) { @("--slot", $Slot) } else { @() }
+    $label = if ($Slot) { "'$AppName' slot '$Slot'" } else { "'$AppName'" }
+
+    $principalId = Invoke-Azure webapp identity show `
+        --name $AppName --resource-group $ResourceGroup @slotArgs `
+        --query principalId --output tsv
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($principalId)) {
+        Write-Log -Level "WARN" -Message "Managed identity not found for $label — assigning..."
+        $null = Invoke-Azure webapp identity assign --name $AppName --resource-group $ResourceGroup @slotArgs --output none
+        $principalId = Invoke-Azure webapp identity show `
+            --name $AppName --resource-group $ResourceGroup @slotArgs `
+            --query principalId --output tsv
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log -Level "ERROR" -Message "Failed to get managed identity for $label."
+            return $null
+        }
+    }
+    return $principalId.Trim()
+}
+
+<#
+.SYNOPSIS
     Grants Cosmos DB Built-in Data Contributor role to a principal (idempotent).
+    Checks for existing assignment FIRST to avoid creating duplicates.
     Returns $true on success or if already assigned.
 #>
 function Grant-CosmosRbac {
     param([string]$AccountName, [string]$ResourceGroup, [string]$PrincipalId, [string]$Scope)
 
+    # Check first — avoid creating duplicate assignments
+    $existingJson = Invoke-Azure cosmosdb sql role assignment list `
+        --account-name $AccountName `
+        --resource-group $ResourceGroup `
+        --output json
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingJson)) {
+        $existing = $existingJson | ConvertFrom-Json
+        $match = $existing | Where-Object {
+            $_.principalId -eq $PrincipalId -and
+            $_.roleDefinitionId -match $CosmosDataContributorRoleId
+        }
+        if ($match) {
+            Write-Log -Level "INFO" -Message "  RBAC already granted — skipped."
+            return $true
+        }
+    }
+
+    # No existing assignment — create one
     $null = Invoke-Azure cosmosdb sql role assignment create `
         --account-name $AccountName `
         --resource-group $ResourceGroup `
@@ -1072,16 +1134,8 @@ function Grant-CosmosRbac {
         --principal-id $PrincipalId `
         --scope $Scope `
         --output none
-    if ($LASTEXITCODE -eq 0) { return $true }
-
-    # Non-zero exit — check if the assignment already exists
-    $existing = Invoke-Azure cosmosdb sql role assignment list `
-        --account-name $AccountName `
-        --resource-group $ResourceGroup `
-        --query "[?principalId=='$PrincipalId']" `
-        --output tsv
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existing)) {
-        Write-Log -Level "DEBUG" -Message "Role already assigned to $PrincipalId — OK."
+    if ($LASTEXITCODE -eq 0) {
+        Write-Log -Level "INFO" -Message "  RBAC granted (new assignment)."
         return $true
     }
 


### PR DESCRIPTION
## Summary

Fixes all 4 blocking CI/CD issues found during staging deployment validation:

- **#77**: Deploy sets `COSMOS_ENDPOINT` + `COSMOS_DATABASE` on production AND all deployment slots
- **#78**: `Get-OrAssignManagedIdentity` handles slots — grants RBAC to all slot identities
- **#79**: Change detection includes `.scripts/` and `.azure/` as backend changes
- **#80**: `Grant-CosmosRbac` checks for existing assignment before creating (no more duplicates)

## Test plan

- [x] Build passes locally
- [ ] Staging deploy triggers correctly with `.scripts/` changes
- [ ] `database.ps1 deploy -Azure` sets app settings on staging slot
- [ ] RBAC granted to staging slot identity without duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)