### PR TITLE
fix: keyboard shortcut improvements — place before purchase, all states

### DIFF
--- a/.scripts/database.ps1
+++ b/.scripts/database.ps1
@@ -663,21 +663,41 @@ function Test-LocalContainerExists {
 #>
 function Invoke-LocalSeed {
     Write-Log -Level "INFO" -Message "Seeding: ensuring database '$DatabaseName' exists..."
-    Invoke-CosmosRest -Method "POST" -Path "/dbs" -ResourceType "dbs" `
-        -Body @{ id = $DatabaseName } | Out-Null
 
-    foreach ($name in $Containers.Keys) {
-        $partKey = $Containers[$name]
-        Write-Log -Level "INFO" -Message "  Container '$name' ($partKey)..."
-        $body = @{
-            id             = $name
-            partitionKey   = @{ paths = @($partKey); kind = "Hash"; version = 2 }
-            indexingPolicy = $ContainerIndexPolicies[$name]
-        }
-        Invoke-CosmosRest -Method "POST" -Path "/dbs/$DatabaseName/colls" `
-            -ResourceType "colls" -ResourceId "dbs/$DatabaseName" -Body $body | Out-Null
+    # Use SDK — handles retries for 503 (emulator still starting) internally
+    $client = New-CosmosClient -IsAzure:$false -Endpoint $EmulatorEndpoint -Key $EmulatorKey
+    if (-not $client) {
+        Write-Log -Level "ERROR" -Message "Failed to create Cosmos SDK client."
+        return
     }
-    Write-Log -Level "INFO" -Message "Seed complete."
+
+    try {
+        # Retry loop for emulator cold start
+        $deadline = (Get-Date).AddSeconds(90)
+        $db = $null
+        while ($null -eq $db) {
+            try {
+                $db = ($client.CreateDatabaseIfNotExistsAsync($DatabaseName).GetAwaiter().GetResult()).Database
+            } catch {
+                if ((Get-Date) -ge $deadline) { throw }
+                $msg = $_.Exception.Message
+                if ($msg -match "503|ServiceUnavailable|still starting") {
+                    Write-Log -Level "INFO" -Message "  Emulator still starting, retrying in 5s..."
+                    Start-Sleep -Seconds 5
+                } else { throw }
+            }
+        }
+
+        foreach ($name in $Containers.Keys) {
+            $partKey = $Containers[$name]
+            Write-Log -Level "INFO" -Message "  Container '$name' ($partKey)..."
+            $props = [Microsoft.Azure.Cosmos.ContainerProperties]::new($name, $partKey)
+            $db.CreateContainerIfNotExistsAsync($props).GetAwaiter().GetResult() | Out-Null
+        }
+        Write-Log -Level "INFO" -Message "Seed complete."
+    } finally {
+        $client.Dispose()
+    }
 }
 
 # ── Local doctor ────────────────────────────────────────────────────────────────

--- a/react-ui/app/game/[id]/page.tsx
+++ b/react-ui/app/game/[id]/page.tsx
@@ -718,30 +718,25 @@ export default function GamePage(): React.ReactElement {
 
       // Purchase shortcuts — only fire AFTER placement logic above has had a chance.
       // Priority: place already-purchased entitlements first, buy new ones second.
-      // WaitingForNext: s=Settlement, c=City, k=Soldier, r=Road, d=DevCard
-      // WaitingForRoll: k=Soldier only
-      // Unrecognized keys are ignored (no fall-through to other handlers).
-      if (gameState === 'WaitingForNext') {
-        switch (lowerKey) {
-          case 's':
-            if (canPurchaseSettlement) { e.preventDefault(); handleAction('settlement'); }
-            return;
-          case 'c':
-            if (canPurchaseCity) { e.preventDefault(); handleAction('city'); }
-            return;
-          case 'k':
-            if (canPlaySoldier) { e.preventDefault(); handleAction('soldier'); }
-            return;
-          case 'r':
-            if (canPurchaseRoad) { e.preventDefault(); handleAction('road'); }
-            return;
-          case 'd':
-            if (canPurchaseDevCard) { e.preventDefault(); handleAction('devcard'); }
-            return;
-        }
-      } else if (gameState === 'WaitingForRoll' && lowerKey === 'k') {
-        if (canPlaySoldier) { e.preventDefault(); handleAction('soldier'); }
-        return;
+      // No game-state gating here — the canPurchase* flags already encode whether
+      // the purchase is valid in the current state (server sets enabled:false when not).
+      // Works in WaitingForNext, WaitingForRoll (soldier), Supplemental, etc.
+      switch (lowerKey) {
+        case 's':
+          if (canPurchaseSettlement) { e.preventDefault(); handleAction('settlement'); }
+          return;
+        case 'c':
+          if (canPurchaseCity) { e.preventDefault(); handleAction('city'); }
+          return;
+        case 'k':
+          if (canPlaySoldier) { e.preventDefault(); handleAction('soldier'); }
+          return;
+        case 'r':
+          if (canPurchaseRoad) { e.preventDefault(); handleAction('road'); }
+          return;
+        case 'd':
+          if (canPurchaseDevCard) { e.preventDefault(); handleAction('devcard'); }
+          return;
       }
     };
 

--- a/react-ui/app/game/[id]/page.tsx
+++ b/react-ui/app/game/[id]/page.tsx
@@ -698,22 +698,22 @@ export default function GamePage(): React.ReactElement {
 
         // Then try city upgrades (reverse alphabet: Z=0, Y=1, X=2, etc.)
         const hasCityEntitlement = currentPlayer?.unspentEntitlements?.includes('City');
-        if (!hasCityEntitlement || !buildings || !currentPlayer) return;
+        if (hasCityEntitlement && buildings && currentPlayer) {
+          const upgradeableSettlements = buildings.filter(
+            (b) => b.buildingState === 'Settlement' && b.ownerId === currentPlayer.id
+          );
 
-        // Build list of upgradeable settlements (same logic as GameBoard)
-        const upgradeableSettlements = buildings.filter(
-          (b) => b.buildingState === 'Settlement' && b.ownerId === currentPlayer.id
-        );
+          // Reverse alphabet mapping: Z=0, Y=1, X=2, etc.
+          const cityIndex = 25 - letterIndex; // Z (25) -> 0, Y (24) -> 1, etc.
 
-        // Reverse alphabet mapping: Z=0, Y=1, X=2, etc.
-        const cityIndex = 25 - letterIndex; // Z (25) -> 0, Y (24) -> 1, etc.
-
-        if (cityIndex >= 0 && cityIndex < upgradeableSettlements.length) {
-          const settlement = upgradeableSettlements[cityIndex];
-          console.log('[GamePage] Keyboard shortcut: upgrading settlement', key);
-          proxy.upgradeBuilding(settlement.buildingKey);
-          return;
+          if (cityIndex >= 0 && cityIndex < upgradeableSettlements.length) {
+            const settlement = upgradeableSettlements[cityIndex];
+            console.log('[GamePage] Keyboard shortcut: upgrading settlement', key);
+            proxy.upgradeBuilding(settlement.buildingKey);
+            return;
+          }
         }
+        // Letter didn't match any road or city — fall through to purchase shortcuts
       }
 
       // Purchase shortcuts — only fire AFTER placement logic above has had a chance.


### PR DESCRIPTION
## Summary

Follow-up fixes to keyboard shortcuts (PR #88):

- **Place before purchase:** Shortcuts now try placing already-owned entitlements (number/letter keys) before attempting to buy new ones
- **Fix fall-through bug:** A-Z handler no longer blocks purchase shortcuts when no city entitlement exists
- **All game states:** Purchase shortcuts work in WaitingForNext, WaitingForRoll, Supplemental, and any state where the server enables the purchase
- **Local emulator:** Switched seed from REST to SDK with 503 retry loop for cold starts

## Test plan

- [x] Press `s` to buy settlement in WaitingForNext
- [x] Press `s` to buy settlement in Supplemental
- [x] Number keys still place settlements when entitlement owned
- [x] Unrecognized keys ignored (no accidental road building)

🤖 Generated with [Claude Code](https://claude.com/claude-code)