### PR TITLE
Fix session path references in ai-rules.md

### DIFF
--- a/.ai/ai-rules.md
+++ b/.ai/ai-rules.md
@@ -304,8 +304,7 @@ After writing or modifying any markdown file:
 Catan/
 ├── .ai/                    # AI assistant rules and documentation
 ├── .claude/                # Claude-specific commands and configurations
-│   ├── commands/          # Reusable command scripts
-│   └── sessions/          # Session summaries
+│   └── commands/          # Reusable command scripts
 ├── .design/               # Verified design documentation (30 docs)
 │   ├── plans/            # Implementation plans awaiting approval
 │   └── old/              # Legacy/superseded docs for reference
@@ -616,11 +615,12 @@ Code reviews and design reviews go in `.design/reviews/`:
 1. Run `start-session.md` command to load context
 2. Check `git status` and recent commits
 3. Review `.ai/project-summary.md` for latest state
-4. **Discovery phase**: Consult `.design/` directory for current architecture
+4. Read the latest session summary in `.ai/sessions/` for recent work context
+5. **Discovery phase**: Consult `.design/` directory for current architecture
    - Start with `.design/README.md` for the document index
    - Reference relevant design documents as needed
    - Legacy docs are in `.design/old/` for historical reference
-5. Identify current task and next priorities
+6. Identify current task and next priorities
 
 ### During a Session
 
@@ -632,7 +632,7 @@ Code reviews and design reviews go in `.design/reviews/`:
 ### Ending a Session
 
 1. Run `handover.md` command
-2. Create/update `SESSION_SUMMARY-{date}.md`
+2. Create/update `.ai/sessions/SESSION_SUMMARY-{date}.md`
 3. Update `.ai/project-summary.md` with session highlights
 4. Commit all valuable work
 5. Document clear next steps

--- a/.ai/commands/code-review.md
+++ b/.ai/commands/code-review.md
@@ -245,9 +245,10 @@ Code reviews ensure:
 **Document all findings in `.code-reviews/` directory:**
 
 1. **Create Review Files**
-   - One file per reviewed source: `.code-reviews/<file-name>-cr-<ai>.md`
+   - One file per reviewed source: `.code-reviews/<code review area>/<file-name>-cr-<ai>.md`
    - Use consistent format (see Findings Format below)
    - Include file path, review date, and reviewer
+   - Code review area is a placeholder for a logical name to place the code reviews.
 
 2. **Categorize Findings**
    - **Critical:** Must be fixed (security, correctness, breaking changes)


### PR DESCRIPTION
Fix inconsistencies in `.ai/ai-rules.md` session path references:

- Remove incorrect `sessions/` under `.claude/` in Project Structure diagram (sessions live in `.ai/sessions/`)
- Add explicit `.ai/sessions/` path in "Ending a Session" instructions
- Add step to read latest session summary in "Starting a Session" workflow
- Minor update to `.ai/commands/code-review.md`