### PR TITLE
fix(replay): make Open Game "Replay" actually work (#145)

### DIFF
--- a/.design/replay-fix.md
+++ b/.design/replay-fix.md
@@ -1,0 +1,216 @@
+# Design: Fix Replay Action (Issue #145)
+
+## Problem
+
+The "Replay" menu option on the Open Game page does not work. Replay is
+supposed to clone a saved game so the same players can play again on the same
+board, starting from `GameState.WaitingForRollForOrder`. Three defects break
+this:
+
+1. **GameId / GameName never get rewritten.** The backend rewrites the cloned
+   snapshots with a string replace targeting PascalCase, space-free JSON
+   (`"GameId":"..."`), but the serializer emits camelCase
+   (`"gameId":"..."`). The replace never matches, so the replay's GameModel
+   keeps the **original** GameId while it is registered and persisted under a
+   **new** GUID. The registry key and the model's own `GameId` disagree, which
+   breaks the SignalR join — the visible "doesn't work" symptom.
+
+2. **Randomness is not reset.** The retained `WaitingForRollForOrder` snapshot
+   still carries the original game's `ReplayableRandom` (seed + iterations at
+   that moment). Replaying from it reproduces the original game's exact dice —
+   a deterministic re-watch, not a fresh play.
+
+3. **No navigation after replay.** The frontend creates the replay, refreshes
+   the list, and drops the new game into inline rename mode. It never opens
+   the game, so clicking Replay appears to do nothing.
+
+## Relevant Code
+
+| Concern | Location |
+|---------|----------|
+| Replay endpoint | `Catan3.GameService/Controllers/GameApiController.cs:764-865` |
+| Snapshot string replace (bug 1) | `GameApiController.cs:811-815` |
+| Serializer casing | `Catan3.Shared/Utility/JsonHelper.cs:20` |
+| `ReplayableRandom` | `Catan3.Shared/Utility/ReplayableRandom.cs` |
+| `DoneStack` ordering / round-trip | `Catan3.Shared/Utility/Log.cs:284-339` |
+| Replay handler (frontend) | `react-ui/app/load-game/page.tsx:251-277` |
+| `replayGame` API client | `react-ui/lib/api/gameApi.ts:326-334` |
+| Original feature design | `.design/load-game-copy-replay.md` |
+
+## Decisions (from design conversation)
+
+- **Random behavior: brand-new random.** The replay gets a fresh, independent
+  `ReplayableRandom` (new random seed, `Iterations = 0`). The board layout and
+  player roster are preserved automatically because they are concrete data in
+  the `WaitingForRollForOrder` snapshot — `Shuffle()` is not re-run on replay,
+  so changing the seed cannot change the board.
+  - **Deviation from issue #145:** the issue text asks for the *same* seed
+    with `Iterations` advanced to one past the original game's last value.
+    Brand-new random was chosen instead: simpler, no need to scan the full
+    history for the max iteration count, and player-indistinguishable from the
+    issue's approach (both yield fresh, reproducible-but-different dice; the
+    board is identical either way). Recorded here for traceability.
+- **Post-replay UX: open the new game immediately.** After a successful
+  replay, navigate to `/game/{newGameId}` so the group lands in
+  `WaitingForRollForOrder` ready to play, instead of returning to the list in
+  rename mode.
+
+## Approach
+
+### Backend: reuse the loadmodel path, not string replace
+
+Replace the fragile string replacement with: an eligibility guard, then
+deserialize the single `WaitingForRollForOrder` snapshot, reset its identity
+and randomness, and seed a fresh game from it via the existing
+`InitializeLoggingState` path.
+
+1. Load the source game (registry or database) — unchanged.
+2. **Eligibility guard:** read the source game's *current* state
+   (`GetCurrentState()`); if `RollModel.GameRollModel.TotalRolls <= 0`, return
+   422 — a game with no rolls was never played, so there is nothing to replay.
+   `TotalRolls` is judged from the current state, not the
+   `WaitingForRollForOrder` snapshot (where it is always `0`).
+3. Find the oldest `WaitingForRollForOrder` snapshot in the `DoneStack` —
+   unchanged (this logic is correct). Its `replayIndex < 0` → 422 stays as
+   defensive cover (unreachable once the rolls guard passes).
+4. Deserialize that snapshot to `GameModel`, then set:
+   - `GameId` = new GUID
+   - `GameName` = provided name or `"{OriginalName} (Replay)"`
+   - `Random` = a fresh `ReplayableRandom()` (new seed, `Iterations = 0`)
+   - `GameState` confirmed to be `WaitingForRollForOrder`
+5. Seed the new game via the same path `loadmodel` / `HandleNewGameAsync`
+   use: empty `Log<string>` →
+   `CreateGameStateMachineWithServiceDependencies` →
+   `InitializeLoggingState(model)` → register under the new GameId. Then
+   persist (compress `GetSerializableLog()` + `SaveAsync`).
+
+This removes any dependency on JSON property casing, drops the manual
+`SerializableLog` assembly in favour of a proven API, and guarantees the
+registry key, the persisted key, and `GameModel.GameId` all agree.
+
+### DoneStack shape (decided)
+
+The replay's `DoneStack` contains exactly **one** entry — the mutated
+`WaitingForRollForOrder` snapshot. `RedoStack` is empty.
+
+Rationale: a single entry means no undo back into board-picking, and there is
+no second snapshot carrying a stale `Random` that undo/redo could promote back
+to "current." It matches the issue's intent ("starting with the
+WaitingForRollForOrder state"). Confirmed by the developer.
+
+Note: with one entry there is nothing to undo, so an `Undo` at the very first
+replay state is rejected by the `GameStateMachine` (existing behavior — it
+throws "nothing to undo"), not silently absorbed. The test therefore proves
+the single-entry shape via the persisted `turnCount == 1`, not by invoking
+`Undo`.
+
+### Frontend: navigate on success
+
+In `handleReplayGame` (`load-game/page.tsx`), after `gameApi.replayGame`
+returns success, call `router.push(\`/game/${newGameId}\`)` instead of
+refreshing the list and entering rename mode — mirroring the existing
+`openGame` path. The backend already registers the new game in the
+`GameStateMachineRegistry`, so it is immediately joinable via SignalR.
+
+## Data Flow (after fix)
+
+```text
+User clicks Replay
+  → POST /api/game/{gameId}/replay
+      → load source game
+      → eligibility: current state TotalRolls > 0  (else 422)
+      → find oldest WaitingForRollForOrder snapshot
+      → deserialize snapshot → set new GameId, GameName, fresh Random
+      → InitializeLoggingState(model)  → single-entry log
+      → register under newGameId + persist
+      → 200 { success, newGameId, gameName }
+  → frontend router.push(/game/{newGameId})
+      → SignalR join → GameModel (WaitingForRollForOrder, same board,
+        same players, fresh randomness)
+```
+
+## What Stays the Same
+
+- The `DoneStack` search for the oldest `WaitingForRollForOrder` state.
+- Registry registration and database persistence mechanics.
+- The `replayGame` API client signature (`gameId`, optional `newName`).
+- Copy, Rename, Delete, Load actions — untouched.
+- The 422 response when no `WaitingForRollForOrder` state exists.
+
+## Automated Testing
+
+A new integration test follows the repo convention: a `WebApplicationFactory`
+test driving the server through `GameServiceProxy`, the same infrastructure as
+`ReplayTests/ReplayTest.cs`. Not a direct controller unit test — the repo has
+no precedent for those.
+
+**New file:** `Tests/GameService/ReplayTests/ReplayEndpointTests.cs`
+
+### Fixture: the longest already-seeded game
+
+The standard workflow always seeds the database after creating it
+(`./catan.ps1 database install` → `Invoke-SeedDefaultData` loads
+`Default Data/Games/`), and the Cosmos emulator persists that data across
+runs. So the test **assumes the seed games are present** and picks one at
+runtime rather than committing a new fixture:
+
+1. `GET /api/games?playerId=*` → all saved games.
+2. If the list is empty, `Assert.Fail` with a clear message:
+   *"No seeded games found — run `./catan.ps1 database install`."*
+3. Pick the game with the highest `TurnCount` (longest game → its `DoneStack`
+   is guaranteed to contain a `WaitingForRollForOrder` snapshot).
+
+No new fixture is committed and the seeding pipeline is unchanged.
+
+### Positive test — `Replay_FromLongestSeedGame_ResetsToRollForOrder`
+
+1. Select the highest-`TurnCount` game from `GET /api/games` (fail clearly if
+   none — see fixture note above).
+2. `POST /api/game/{originalId}/load` to register it from the DB; join it and
+   capture original `GameModel`: tiles (resource per tile key), numbers,
+   harbors, player Ids.
+3. `POST /api/game/{originalId}/replay` → `newGameId`.
+4. Join `newGameId` and assert the returned `GameModel`:
+
+| Assertion | Proves |
+|-----------|--------|
+| Join succeeds; `GameId == newGameId` and `!= originalId` | Loads OK; Bug 1 (GameId rewrite) |
+| `GameState == WaitingForRollForOrder` | Correct start state |
+| Tiles, numbers, harbors identical to original | Same board |
+| Same player Ids present | All players present |
+| No player resources / score / dev cards; no owned buildings; no owned roads | Clean reset |
+| `random.iterations == 0` and `random.seed != original` | Bug 2 (fresh random) |
+| replay listed by `GET /api/games` with `turnCount == 1` | Single-entry history (nothing to undo into setup) |
+
+### Negative test — `Replay_NeverRolledGame_Returns422`
+
+Create a game via `POST /api/game/new`, leave it in `PickingBoard`
+(`TotalRolls == 0`), call replay → assert HTTP 422 (eligibility guard).
+
+**Run:** `dotnet test Tests\GameService\Tests.GameService.csproj --filter "ReplayEndpointTests"`
+(and via `./catan.ps1 test`, which starts the Cosmos emulator the integration
+tests require).
+
+## Manual Verification
+
+1. `pwsh ./catan.ps1 build` — solution builds.
+2. Play a game past board setup into mid-game; save it.
+3. From the Open Game page, click Replay on that game.
+4. Confirm: the app navigates straight into the new game; state is
+   `WaitingForRollForOrder`; board layout and player roster match the
+   original; the URL/game uses the new GUID.
+5. Roll for order and play a few turns; confirm dice differ from the original
+   playthrough (fresh randomness).
+6. Reload the replay from the Open Game page; confirm it loads correctly under
+   its own GUID (proves GameId was rewritten).
+7. Replay a game still in board setup (no `WaitingForRollForOrder` yet);
+   confirm a clear error, not a crash.
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `Catan3.GameService/Controllers/GameApiController.cs` | Add `TotalRolls > 0` eligibility guard; deserialize the snapshot, set new `GameId`/`GameName`/fresh `Random`, seed via `InitializeLoggingState`; delete the string-replace and manual `SerializableLog` assembly |
+| `react-ui/app/load-game/page.tsx` | Navigate to `/game/{newGameId}` on replay success |
+| `Tests/GameService/ReplayTests/ReplayEndpointTests.cs` | New — positive (longest seed game) + negative (never-rolled → 422) integration tests |
+| `Catan3.GameService/Controllers/RecordingController.cs` | Drive-by: guard null id in `ReplayRecording` (fixes pre-existing CS8604) |

--- a/Catan3.GameService/Controllers/GameApiController.cs
+++ b/Catan3.GameService/Controllers/GameApiController.cs
@@ -757,8 +757,10 @@ namespace Catan3.GameService.Controllers
         }
 
         /// <summary>
-        /// Creates a copy of the game reset to the first WaitingForRollForOrder state,
-        /// so the same group can play again on the same board without setup.
+        /// Creates a new game from an actually-played game (at least one roll),
+        /// reset to its first WaitingForRollForOrder state, so the same group can
+        /// play again on the same board and players without setup. The replay gets
+        /// a fresh GameId, name, and randomness, and a single-entry history.
         /// POST /api/game/{gameId}/replay
         /// </summary>
         [HttpPost("game/{gameId}/replay")]
@@ -773,7 +775,20 @@ namespace Catan3.GameService.Controllers
                     return NotFound(new { success = false, error = $"Game {gameId} not found" });
 
                 var sourceLog = sourceGameStateMachine.GetSerializableLog();
-                var originalName = sourceGameStateMachine.GetCurrentState().GameName;
+                var sourceCurrent = sourceGameStateMachine.GetCurrentState();
+                var originalName = sourceCurrent.GameName;
+
+                // Eligibility: only games that were actually played (at least one
+                // roll) can be replayed. TotalRolls is judged from the CURRENT
+                // state — it is always 0 at the WaitingForRollForOrder snapshot.
+                if (sourceCurrent.RollModel.GameRollModel.TotalRolls <= 0)
+                {
+                    return UnprocessableEntity(new
+                    {
+                        success = false,
+                        error = "Game has no rolls — it was never played, nothing to replay."
+                    });
+                }
 
                 // Find the first WaitingForRollForOrder state in game history.
                 // DoneStack[0] = most recent, DoneStack[Count-1] = oldest.
@@ -791,6 +806,8 @@ namespace Catan3.GameService.Controllers
 
                 if (replayIndex < 0)
                 {
+                    // Defensive: unreachable once the rolls guard passes (a rolled
+                    // game must have passed through the logged WaitingForRollForOrder).
                     return UnprocessableEntity(new
                     {
                         success = false,
@@ -803,32 +820,33 @@ namespace Catan3.GameService.Controllers
                     ? newName
                     : $"{originalName} (Replay)";
 
-                // Truncate DoneStack to WaitingForRollForOrder (keep oldest states from replayIndex onward)
-                // and replace GameId / GameName in every entry.
-                var newDoneStack = new List<string>();
-                for (int i = replayIndex; i < sourceLog.DoneStack.Count; i++)
-                {
-                    var updatedJson = sourceLog.DoneStack[i]
-                        .Replace($"\"GameId\":\"{gameId}\"", $"\"GameId\":\"{newGameId}\"")
-                        .Replace($"\"GameName\":\"{originalName}\"", $"\"GameName\":\"{gameName}\"");
-                    newDoneStack.Add(updatedJson);
-                }
+                // Deserialize the WaitingForRollForOrder snapshot and reset its
+                // identity and randomness. The board and players are concrete data
+                // in this snapshot and are preserved as-is (Shuffle() is not
+                // re-run). A brand-new ReplayableRandom gives fresh dice that do
+                // not collide with the original game's sequence.
+                var model = JsonHelper.Deserialize<GameModel>(sourceLog.DoneStack[replayIndex])
+                    ?? throw new InvalidOperationException("Failed to deserialize WaitingForRollForOrder snapshot");
+                model.GameId = newGameId;
+                model.GameName = gameName;
+                model.Random = new ReplayableRandom();
+                model.Validate();
+                model.UpdateGameHash();
 
-                var newSerializableLog = new SerializableLog
-                {
-                    DoneStack = newDoneStack,
-                    RedoStack = [],
-                    GameType = sourceLog.GameType,
-                    DoneCount = newDoneStack.Count,
-                    RedoCount = 0
-                };
-
-                var newGameLog = Log<string>.FromSerializableLog(newSerializableLog, _persistenceService, string.Empty);
+                // Seed a fresh single-entry game from the snapshot using the same
+                // path loadmodel / HandleNewGameAsync use. InitializeLoggingState
+                // makes this snapshot the sole starting state — no undo back into
+                // board-pick, no stale Random promoted by undo/redo.
+                var newGameLog = new Log<string>(_persistenceService, string.Empty);
                 var newGameStateMachine = CreateGameStateMachineWithServiceDependencies(newGameLog);
-                var newGameModel = newGameStateMachine.GetCurrentState();
-
+                newGameStateMachine.InitializeLoggingState(model);
                 GameStateMachineRegistry.AddGameStateMachine(newGameId, newGameStateMachine);
 
+                var newGameModel = newGameStateMachine.GetCurrentState();
+
+                // Persist so the replay appears in the saved-games store —
+                // InitializeLoggingState only registers it in memory.
+                var newSerializableLog = newGameStateMachine.GetSerializableLog();
                 var json = JsonHelper.Serialize(newSerializableLog);
                 var compressed = JsonHelper.Compress(json);
 

--- a/Catan3.GameService/Controllers/RecordingController.cs
+++ b/Catan3.GameService/Controllers/RecordingController.cs
@@ -374,6 +374,11 @@ public class RecordingController : ControllerBase
         // Sanitize user-provided id for log safety
         var safeId = id?.Replace(Environment.NewLine, " ").Replace("\r", " ").Replace("\n", " ") ?? "";
 
+        if (string.IsNullOrEmpty(id))
+        {
+            return NotFound(new { message = $"Recording {safeId} not found" });
+        }
+
         // Load the recording
         var result = await _recordingService.GetRecordingAsync(id);
         if (result == null)

--- a/Tests/GameService/ReplayTests/ReplayEndpointTests.cs
+++ b/Tests/GameService/ReplayTests/ReplayEndpointTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Catan3.Shared.Models;
+using Catan3.Shared.Utility;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.GameService
+{
+    /// <summary>
+    /// Integration tests for POST /api/game/{gameId}/replay (issue #145).
+    ///
+    /// The positive test reuses the longest already-seeded game (the standard
+    /// workflow always seeds the DB via `./catan.ps1 database install`), replays
+    /// it, and verifies the new game is a clean reset to WaitingForRollForOrder
+    /// with the same board/players, fresh randomness, and a single-entry history.
+    ///
+    /// The negative test verifies the eligibility guard: a game that was never
+    /// rolled cannot be replayed (HTTP 422).
+    /// </summary>
+    public class ReplayEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+        private readonly ITestOutputHelper _output;
+
+        public ReplayEndpointTests(WebApplicationFactory<Program> factory, ITestOutputHelper output)
+        {
+            _output = output;
+            _factory = factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((context, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["GameApi:HangingGetTimeoutSeconds"] = "5",
+                    });
+                });
+            });
+        }
+
+        private (Uri uri, HttpMessageHandler handler) Conn()
+        {
+            var uri = _factory.Server.BaseAddress ?? new Uri("http://localhost");
+            return (uri, _factory.Server.CreateHandler());
+        }
+
+        private static async Task<GameModel> GetGameModelAsync(HttpClient http, string gameId)
+        {
+            var resp = await http.GetAsync($"/api/gamestate/{gameId}");
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.True(resp.IsSuccessStatusCode, $"GET /api/gamestate/{gameId} failed: {(int)resp.StatusCode} {body}");
+            return JsonHelper.Deserialize<GameModel>(body)
+                ?? throw new InvalidOperationException($"Could not deserialize GameModel for {gameId}");
+        }
+
+        private static string TileSig(IEnumerable<TileModel> tiles) => string.Join("|",
+            tiles.Select(t => $"{t.TileKey.Q},{t.TileKey.R},{t.TileKey.S}:{t.ResourceTileType}:{t.Number}")
+                 .OrderBy(s => s, StringComparer.Ordinal));
+
+        private static string HarborSig(IEnumerable<HarborModel> harbors) => string.Join("|",
+            harbors.Select(h => h.HarborKey.ToString()).OrderBy(s => s, StringComparer.Ordinal));
+
+        [Fact]
+        public async Task Replay_FromLongestSeedGame_ResetsToRollForOrder()
+        {
+            var (uri, handler) = Conn();
+            using var http = new HttpClient(handler) { BaseAddress = uri };
+
+            // 1. Pick the longest already-seeded game.
+            var listResp = await http.GetAsync("/api/games?playerId=*");
+            var listBody = await listResp.Content.ReadAsStringAsync();
+            Assert.True(listResp.IsSuccessStatusCode, $"GET /api/games failed: {(int)listResp.StatusCode} {listBody}");
+
+            using var listDoc = JsonDocument.Parse(listBody);
+            var games = listDoc.RootElement.GetProperty("games");
+            if (games.GetArrayLength() == 0)
+            {
+                Assert.Fail("No seeded games found — run `./catan.ps1 database install` to seed the database.");
+            }
+
+            string originalId = "";
+            int bestTurns = -1;
+            foreach (var g in games.EnumerateArray())
+            {
+                var turns = g.TryGetProperty("turnCount", out var tc) ? tc.GetInt32() : 0;
+                if (turns > bestTurns)
+                {
+                    bestTurns = turns;
+                    originalId = g.GetProperty("gameId").GetString() ?? "";
+                }
+            }
+            Assert.False(string.IsNullOrEmpty(originalId), "Could not select a seed game id.");
+            _output.WriteLine($"Selected longest seed game {originalId} ({bestTurns} turns)");
+
+            // 2. Replay it.
+            var replayResp = await http.PostAsync($"/api/game/{originalId}/replay", null);
+            var replayBody = await replayResp.Content.ReadAsStringAsync();
+            Assert.True(replayResp.IsSuccessStatusCode,
+                $"Replay failed ({(int)replayResp.StatusCode}). The longest seed game may not be a played game " +
+                $"(needs >=1 roll and a WaitingForRollForOrder state). Body: {replayBody}");
+
+            using var replayDoc = JsonDocument.Parse(replayBody);
+            var newGameId = replayDoc.RootElement.GetProperty("newGameId").GetString() ?? "";
+            Assert.False(string.IsNullOrEmpty(newGameId), "Replay did not return a newGameId.");
+            Assert.NotEqual(originalId, newGameId);
+
+            // 3. Capture original (current) and replay models. Both are now in the
+            //    registry (replay's EnsureGameLoadedAsync loaded the original).
+            var original = await GetGameModelAsync(http, originalId);
+            var replay = await GetGameModelAsync(http, newGameId);
+
+            // 4a. Bug 1 — GameId rewritten; registry key and model agree.
+            Assert.Equal(newGameId, replay.GameId);
+            Assert.NotEqual(originalId, replay.GameId);
+
+            // 4b. Reset to the correct start state.
+            Assert.Equal(GameState.WaitingForRollForOrder, replay.GameState);
+
+            // 4c. Same board (tiles + numbers + harbors) and same players.
+            Assert.Equal(TileSig(original.Tiles), TileSig(replay.Tiles));
+            Assert.Equal(HarborSig(original.Harbors), HarborSig(replay.Harbors));
+            Assert.Equal(
+                original.Players.Select(p => p.Id).OrderBy(s => s, StringComparer.Ordinal),
+                replay.Players.Select(p => p.Id).OrderBy(s => s, StringComparer.Ordinal));
+
+            // 4d. Clean reset — no placed buildings/roads, no player stats.
+            Assert.DoesNotContain(replay.Buildings, b => !string.IsNullOrEmpty(b.OwnerId));
+            Assert.DoesNotContain(replay.Roads, r => !string.IsNullOrEmpty(r.OwnerId) || r.RoadState != RoadState.Unowned);
+            foreach (var p in replay.Players)
+            {
+                Assert.Equal(0, p.Score);
+                Assert.Equal(0, p.ResourcesThisGame.Count);
+                Assert.Equal(0, p.ResourcesThisTurn.Count);
+                Assert.Empty(p.UnspentEntitlements);
+                Assert.Empty(p.SpentEntitlementsThisGame);
+            }
+
+            // 4e. Bug 2 — fresh randomness.
+            Assert.Equal(0, replay.Random.Iterations);
+            Assert.NotEqual(original.Random.Seed, replay.Random.Seed);
+
+            // 4f. Single-entry history — the replay is persisted with
+            //     TurnCount = DoneCount, so the new game has exactly one log
+            //     entry (nothing to undo back into board-pick). The old buggy
+            //     behavior kept the whole setup history (turnCount > 1).
+            var listResp2 = await http.GetAsync("/api/games?playerId=*");
+            var listBody2 = await listResp2.Content.ReadAsStringAsync();
+            Assert.True(listResp2.IsSuccessStatusCode,
+                $"GET /api/games failed: {(int)listResp2.StatusCode} {listBody2}");
+            using var listDoc2 = JsonDocument.Parse(listBody2);
+            int replayTurns = -1;
+            foreach (var g in listDoc2.RootElement.GetProperty("games").EnumerateArray())
+            {
+                if (g.GetProperty("gameId").GetString() == newGameId)
+                {
+                    replayTurns = g.TryGetProperty("turnCount", out var tc) ? tc.GetInt32() : -1;
+                    break;
+                }
+            }
+            Assert.Equal(1, replayTurns);
+        }
+
+        [Fact]
+        public async Task Replay_NeverRolledGame_Returns422()
+        {
+            var (uri, handler) = Conn();
+            using var http = new HttpClient(handler) { BaseAddress = uri };
+
+            // A brand-new game sits in PickingBoard with TotalRolls == 0.
+            var newGameJson = JsonSerializer.Serialize(new
+            {
+                playerIds = new[] { "p1", "p2", "p3" },
+                gameType = "Regular",
+                gameName = "replay-neg-test",
+            });
+            var createResp = await http.PostAsync("/api/game/new",
+                new StringContent(newGameJson, Encoding.UTF8, "application/json"));
+            var createBody = await createResp.Content.ReadAsStringAsync();
+            Assert.True(createResp.IsSuccessStatusCode, $"POST /api/game/new failed: {(int)createResp.StatusCode} {createBody}");
+
+            using var createDoc = JsonDocument.Parse(createBody);
+            var gameId = createDoc.RootElement.GetProperty("gameId").GetString() ?? "";
+            Assert.False(string.IsNullOrEmpty(gameId));
+
+            var replayResp = await http.PostAsync($"/api/game/{gameId}/replay", null);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, replayResp.StatusCode);
+        }
+    }
+}

--- a/react-ui/app/load-game/page.tsx
+++ b/react-ui/app/load-game/page.tsx
@@ -248,33 +248,28 @@ export default function LoadGame(): React.ReactElement {
     }
   }, []);
 
-  const handleReplayGame = useCallback(async (gameId: string) => {
-    setOpenMenuGameId(null);
-    setErrorMessage(null);
-    try {
-      const result = await gameApi.replayGame(gameId);
-      if (!result.success || !result.data) {
-        setErrorMessage(result.error ?? 'Failed to create replay');
-        return;
-      }
-      const newGameId = result.data.newGameId;
-      const listResult = await gameApi.getSavedGames();
-      if (listResult.success && listResult.data) {
-        setSavedGames(listResult.data);
-        setSelectedGameId(newGameId);
-        const newGame = listResult.data.find((g) => g.gameId === newGameId);
-        if (newGame) {
-          setOriginalName(newGame.gameName);
-          setEditingName(newGame.gameName);
-          setEditingGameId(newGameId);
+  const handleReplayGame = useCallback(
+    async (gameId: string) => {
+      setOpenMenuGameId(null);
+      setErrorMessage(null);
+      try {
+        const result = await gameApi.replayGame(gameId);
+        if (!result.success || !result.data) {
+          setErrorMessage(result.error ?? 'Failed to create replay');
+          return;
         }
+        // The replay endpoint already registered the new game in the
+        // GameStateMachineRegistry, so navigate straight in — the game page
+        // joins via SignalR (mirrors the openGame path).
+        router.push(`/game/${result.data.newGameId}`);
+      } catch (error) {
+        setErrorMessage(
+          `Error creating replay: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
       }
-    } catch (error) {
-      setErrorMessage(
-        `Error creating replay: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
-    }
-  }, []);
+    },
+    [router]
+  );
 
   const deleteCheckedGames = useCallback(async () => {
     if (checkedGameIds.size === 0) return;


### PR DESCRIPTION
## Summary

Fixes the Open Game "Replay" action, which never worked.

### Root cause (three defects)

1. **GameId/GameName never rewritten.** The old code rewrote cloned snapshots
   with a PascalCase, space-free string replace (`"GameId":"..."`), but the
   serializer emits camelCase (`"gameId":"..."`) — the replace never matched.
   The replay kept the *original* GameId while being registered/persisted
   under a new GUID, so the SignalR join broke (the visible "doesn't work").
2. **Randomness not reset** — replay reproduced the original game's exact dice.
3. **No navigation** — the UI entered inline-rename instead of opening the game.

### Fix

- **Backend** (`GameApiController.ReplayGame`): add a `TotalRolls > 0`
  eligibility guard (a game with no rolls was never played → 422, judged from
  the *current* state); deserialize the first `WaitingForRollForOrder`
  snapshot; set a new `GameId`/`GameName` and a fresh `ReplayableRandom`; seed
  the new game via the existing `InitializeLoggingState` path (the same path
  `loadmodel`/`HandleNewGameAsync` use) → single-entry history; persist.
  Deletes the camelCase-broken string-replace **and** the manual
  `SerializableLog` assembly.
- **Frontend** (`load-game/page.tsx`): `handleReplayGame` navigates to
  `/game/{newGameId}` on success (the endpoint already registered the game in
  the registry).
- **Drive-by**: guard a null `id` in `RecordingController.ReplayRecording`,
  fixing a pre-existing CS8604 warning ("to find it is to own it" — the repo
  is now warning-clean).

### Design decisions

- **Random:** brand-new `ReplayableRandom` (new seed, `Iterations = 0`). Board
  and players are concrete snapshot data, preserved as-is (`Shuffle()` is not
  re-run); both this and the issue's "same seed + Iterations+1" idea yield
  fresh, reproducible dice, so the simpler approach was chosen. Deliberate,
  documented deviation from the issue text.
- **Start state:** `WaitingForRollForOrder`, per the issue. Confirmed in
  manual testing — seeing the board before clicking Next is a useful visual
  verification that replay produced the right board.
- **History:** single `WaitingForRollForOrder` entry (no undo back into
  board-pick, no stale `Random`).
- 100% GameService feature — REST lifecycle endpoint, no replay logic in JS.

### Testing

- `pwsh ./catan.ps1 test` — full suite green: GameService (incl. new
  `ReplayEndpointTests`: positive + `Replay_NeverRolledGame_Returns422`),
  Shared 76/76, and TypeScript tests.
- New integration test reuses the longest already-seeded game, replays it, and
  asserts: identical tiles/numbers/harbors, all players present, no
  stats/buildings/roads, fresh random, rewritten GameId, single-entry history
  (`turnCount == 1`).
- Manually verified end-to-end: Replay creates the game and navigates straight
  into it at `WaitingForRollForOrder` with the same board/players.

### Self-review

- Focused 5-file diff; no unrelated churn (line-ending/format noise tracked
  separately in #172).
- Reuses existing proven code paths (`InitializeLoggingState`); no new
  serialization or log assembly.
- Docs: `.design/replay-fix.md` (verified as-built); transient implementation
  plan removed per workflow.

Closes #145
