### PR TITLE
fix: perf.ps1 color threshold order (rescued from longgame-perf)

### DIFF
--- a/.scripts/perf.ps1
+++ b/.scripts/perf.ps1
@@ -138,7 +138,7 @@ foreach ($rec in $recordings) {
     Write-Log -Level INFO -Message ("  {0,5} {1,-22} {2,-22} {3,10}" -f "-----", "----------------------", "----------------------", "----------") -NoLabel -ForegroundColor Gray
 
     foreach ($t in $result.timings) {
-        $color = if ($t.elapsedMs -gt 10) { "Yellow" } elseif ($t.elapsedMs -gt 50) { "Red" } else { "White" }
+        $color = if ($t.elapsedMs -gt 50) { "Red" } elseif ($t.elapsedMs -gt 10) { "Yellow" } else { "White" }
         Write-Log -Level INFO -Message ("  {0,5} {1,-22} {2,-22} {3,10}" -f $t.index, $t.actionType, $t.gameState, $t.elapsedMs) -NoLabel -ForegroundColor $color
     }
 


### PR DESCRIPTION
## What

Rescues a small, real bug fix that was stranded on the orphaned
`longgame-perf` branch (commit `439ea7b`, "PR review finding #4") and never
made it to `main`/`staging`.

## Bug

`.scripts/perf.ps1` colored per-action timings with the threshold checks in
the wrong order:

```powershell
# before — ">10 Yellow" is checked first, so the ">50 Red" branch is
# unreachable dead code (a 60ms timing shows Yellow, not Red)
$color = if ($t.elapsedMs -gt 10) { "Yellow" } elseif ($t.elapsedMs -gt 50) { "Red" } else { "White" }
```

## Fix

Check the higher threshold first:

```powershell
$color = if ($t.elapsedMs -gt 50) { "Red" } elseif ($t.elapsedMs -gt 10) { "Yellow" } else { "White" }
```

One line. Cherry-picked verbatim from `longgame-perf@439ea7b` (original
author/date preserved). Everything else from the long-game-perf effort already
landed via `longgame-perf-v2`; this was the only un-merged content, so
`longgame-perf` is being deleted after this.

Targets `staging` (not `main`) — more work will batch through `staging` before
the next promotion.
